### PR TITLE
Update library version to new snapshot and fix conditions/actions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ repositories {
 }
 
 def profile = props.getProperty('SPRING_PROFILES_ACTIVE')
+def formFlowLibraryVersion = '0.0.2-SNAPSHOT'
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
@@ -39,10 +40,10 @@ dependencies {
 
     if (profile == 'dev') {
         implementation fileTree(dir: "$rootDir/../form-flow/build/libs", include: '*.jar')
-        println "Using local library 🗼"
+        println "📦 Using local library"
     } else {
-        implementation 'org.codeforamerica.platform:form-flow:0.0.1-SNAPSHOT'
-        println "Using 0.0.1-SNAPSHOT 💜"
+        implementation "org.codeforamerica.platform:form-flow:${formFlowLibraryVersion}"
+        println "📚Using form flow library ${formFlowLibraryVersion}"
     }
 
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/org/formflowstartertemplate/app/submission/actions/UpdateIncomeAmountsBeforeSaving.java
+++ b/src/main/java/org/formflowstartertemplate/app/submission/actions/UpdateIncomeAmountsBeforeSaving.java
@@ -5,11 +5,13 @@ import formflow.library.data.Submission;
 
 import java.util.ArrayList;
 import java.util.Map;
+import org.springframework.stereotype.Component;
 
 /**
  * This will update the data submitted for Income Amounts before its saved to the database. It will take the new Income Amount
  * data and reconcile it with the data stored in the database.
  */
+@Component
 public class UpdateIncomeAmountsBeforeSaving implements Action {
 
   public void run(Submission submission, String data) {

--- a/src/main/java/org/formflowstartertemplate/app/submission/actions/UpdatePersonalInfoDates.java
+++ b/src/main/java/org/formflowstartertemplate/app/submission/actions/UpdatePersonalInfoDates.java
@@ -6,8 +6,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 
 @Slf4j
+@Component
 public class UpdatePersonalInfoDates implements Action {
 
   public void run(FormSubmission formSubmission) {

--- a/src/main/java/org/formflowstartertemplate/app/submission/actions/ValidateMovedToUSADate.java
+++ b/src/main/java/org/formflowstartertemplate/app/submission/actions/ValidateMovedToUSADate.java
@@ -8,8 +8,10 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
+import org.springframework.stereotype.Component;
 
 @Slf4j
+@Component
 public class ValidateMovedToUSADate implements Action {
 
   private final String INPUT_NAME = "movedToUSADate";

--- a/src/main/java/org/formflowstartertemplate/app/submission/conditions/AllHouseholdMembersHaveIncome.java
+++ b/src/main/java/org/formflowstartertemplate/app/submission/conditions/AllHouseholdMembersHaveIncome.java
@@ -4,7 +4,9 @@ import formflow.library.config.submission.Condition;
 import formflow.library.data.Submission;
 import java.util.ArrayList;
 import java.util.Map;
+import org.springframework.stereotype.Component;
 
+@Component
 public class AllHouseholdMembersHaveIncome implements Condition {
 
   @Override

--- a/src/main/java/org/formflowstartertemplate/app/submission/conditions/ExceedsIncomeThreshold.java
+++ b/src/main/java/org/formflowstartertemplate/app/submission/conditions/ExceedsIncomeThreshold.java
@@ -3,11 +3,13 @@ package org.formflowstartertemplate.app.submission.conditions;
 import formflow.library.config.submission.Condition;
 import formflow.library.data.Submission;
 import org.formflowstartertemplate.app.utils.SubmissionUtilities;
+import org.springframework.stereotype.Component;
 
 /**
  * This condition will check to see if the income the user has entered exceeds the maximum income allowable, based on their family
  * size.
  */
+@Component
 public class ExceedsIncomeThreshold implements Condition {
 
   public Boolean run(Submission submission) {

--- a/src/main/java/org/formflowstartertemplate/app/submission/conditions/HasHousehold.java
+++ b/src/main/java/org/formflowstartertemplate/app/submission/conditions/HasHousehold.java
@@ -2,7 +2,9 @@ package org.formflowstartertemplate.app.submission.conditions;
 
 import formflow.library.config.submission.Condition;
 import formflow.library.data.Submission;
+import org.springframework.stereotype.Component;
 
+@Component
 public class HasHousehold implements Condition {
 
   public Boolean run(Submission submission) {

--- a/src/main/java/org/formflowstartertemplate/app/submission/conditions/HouseholdMemberAlreadyHasIncome.java
+++ b/src/main/java/org/formflowstartertemplate/app/submission/conditions/HouseholdMemberAlreadyHasIncome.java
@@ -4,7 +4,9 @@ import formflow.library.config.submission.Condition;
 import formflow.library.data.Submission;
 import java.util.ArrayList;
 import java.util.Map;
+import org.springframework.stereotype.Component;
 
+@Component
 public class HouseholdMemberAlreadyHasIncome implements Condition {
 
   @Override

--- a/src/main/java/org/formflowstartertemplate/app/submission/conditions/IncomeSelectedSelf.java
+++ b/src/main/java/org/formflowstartertemplate/app/submission/conditions/IncomeSelectedSelf.java
@@ -4,7 +4,9 @@ import formflow.library.config.submission.Condition;
 import formflow.library.data.Submission;
 import java.util.ArrayList;
 import java.util.Map;
+import org.springframework.stereotype.Component;
 
+@Component
 public class IncomeSelectedSelf implements Condition {
 
   @Override

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -1,6 +1,4 @@
 name: ubi
-conditionsPath: 'org.formflowstartertemplate.app.submission.conditions'
-actionsPath: 'org.formflowstartertemplate.app.submission.actions'
 flow:
   howThisWorks:
     nextScreens:
@@ -12,8 +10,8 @@ flow:
     nextScreens:
       - name: personalInfo
   personalInfo:
-    onPostAction: org.formflowstartertemplate.app.submission.actions.UpdatePersonalInfoDates
-    crossFieldValidationAction: org.formflowstartertemplate.app.submission.actions.ValidateMovedToUSADate
+    onPostAction: UpdatePersonalInfoDates
+    crossFieldValidationAction: ValidateMovedToUSADate
     nextScreens:
       - name: homeAddress
   homeAddress:
@@ -31,7 +29,7 @@ flow:
   housemates:
     nextScreens:
       - name: housemateInfo
-        condition: org.formflowstartertemplate.app.submission.conditions.HasHousehold
+        condition: HasHousehold
       - name: income
   housemateInfo:
     subflow: household
@@ -54,21 +52,21 @@ flow:
     nextScreens:
       - name: incomeAmounts
   incomeAmounts:
-    beforeSaveAction: org.formflowstartertemplate.app.submission.actions.UpdateIncomeAmountsBeforeSaving
+    beforeSaveAction: UpdateIncomeAmountsBeforeSaving
     subflow: income
     nextScreens:
       - name: annualHouseholdIncome
   annualHouseholdIncome:
     nextScreens:
       - name: exceedsIncomeThreshold
-        condition: org.formflowstartertemplate.app.submission.conditions.ExceedsIncomeThreshold
+        condition: ExceedsIncomeThreshold
       - name: incomeComplete
   incomeDeleteConfirmation:
     nextScreens: null
   reportedAnnualHouseholdIncome:
     nextScreens:
       - name: exceedsIncomeThreshold
-        condition: org.formflowstartertemplate.app.submission.conditions.ExceedsIncomeThreshold
+        condition: ExceedsIncomeThreshold
       - name: incomeComplete
   incomeComplete:
     nextScreens:


### PR DESCRIPTION
- Lock in to library version `0.0.2-SNAPSHOT`
  - We decided that `0.0.1-SNAPSHOT` will now the f[rozen version of the library](https://github.com/codeforamerica/form-flow/releases/tag/0.0.1-SNAPSHOT) for Doc LA to use for their research trip
  - Now all future rolling changes to the library will be pushed to `0.0.2-SNAPSHOT`
  - More info in our [pivotal tracker ticket](https://www.pivotaltracker.com/story/show/184730706) if you're curious
- Update condition/action paths