### PR TITLE
Add 404 page

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -391,3 +391,8 @@ contact-info.the-center-of-ubi-may-send-you-text=The Center for UBI may send you
 contact-info.phone-number-placeholder=(999) 999-9999
 contact-info.invalid-phone-number=Please make sure you are entering a valid 10-digit phone number, area code first. 
 contact-info.invalid-email=Please make sure you are entering a valid email address.
+
+# errors
+error-404.title=Page not found
+error-404.header=Sorry, the page you are looking for doesn't exist.
+error-404.subtext=You may want to try starting again from our homepage.

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}">
+<head th:replace="fragments/head :: head(title=#{error-404.title})"></head>
+<body>
+<div class="page-wrapper">
+  <div th:replace="fragments/toolbar :: toolbar"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="fragments/goBack :: goBackLink"></div>
+      <main id="content" role="main" class="form-card spacing-above-35">
+        <th:block th:replace="'fragments/icons' :: error"></th:block>
+        <th:block
+            th:replace="'fragments/cardHeader' :: cardHeader(header=#{error-404.header}, subtext=#{error-404.subtext})"/>
+      </main>
+    </div>
+  </section>
+</div>
+<th:block th:replace="fragments/footer :: footer"/>
+</body>
+</html>

--- a/src/main/resources/templates/error/500.html
+++ b/src/main/resources/templates/error/500.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}">
+<head th:replace="fragments/head :: head(title=#{error.error})"></head>
+<body>
+<div class="page-wrapper">
+  <div th:replace="fragments/toolbar :: toolbar"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="fragments/goBack :: goBackLink"></div>
+      <main id="content" role="main" class="form-card spacing-above-35">
+        <th:block th:replace="'fragments/icons' :: error"></th:block>
+        <th:block
+            th:replace="'fragments/cardHeader' :: cardHeader(header=#{error.uh-oh}, subtext=#{error.we-are-sorry})"/>
+      </main>
+    </div>
+  </section>
+</div>
+<th:block th:replace="fragments/footer :: footer"/>
+</body>
+</html>


### PR DESCRIPTION
It will be nice to know when there's an error due to server error vs a routing issue (page not found).

Apparently we can just do this by putting a file named "404.html" in the right place. I copied the 500 error page from the form-flow library and copied it for 404 as well (with updated strings I stole from GCF).

<img width="1078" alt="image" src="https://user-images.githubusercontent.com/129120/230507654-199194d7-8b7c-4f88-b637-441451accd42.png">
