### PR TITLE
Add sentry for error tracking

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -46,7 +46,8 @@ jobs:
           'SPRING_DATASOURCE_USERNAME=${{ secrets.SPRING_DATASOURCE_USERNAME }}' \
           'SPRING_DATASOURCE_PASSWORD=${{ secrets.SPRING_DATASOURCE_PASSWORD }}' \
           'MAILGUN_API_KEY=${{ secrets.MAILGUN_API_KEY }}' \
-          'MAILGUN_DOMAIN=${{ vars.MAILGUN_DOMAIN }}'
+          'MAILGUN_DOMAIN=${{ vars.MAILGUN_DOMAIN }}' \
+          'SENTRY_DSN=${{ secrets.SENTRY_DSN }}'
       - name: Announce on Slack when deploy fails
         if: failure()
         uses: ravsamhq/notify-slack-action@v2

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
 
     implementation 'com.mailgun:mailgun-java:1.0.7'
 
+    implementation 'io.sentry:sentry-spring-boot-starter:6.17.0'
+
     if (profile == 'dev') {
         implementation fileTree(dir: "$rootDir/../form-flow/build/libs", include: '*.jar')
         println "📦 Using local library"


### PR DESCRIPTION
I'm unsure whether this will work with no further configuration, so this is a bit experimental. I believe this will read from the SENTRY_DSN environment variable (which I just added to Github).