### PR TITLE
Add ForwardedHeaderFilter to keep "https" as the scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Form Flow Starter Application
+# Homeschool-PEBT
 
 Table of Contents
 =================

--- a/src/main/java/org/homeschoolpebt/app/config/SecurityConfiguration.java
+++ b/src/main/java/org/homeschoolpebt/app/config/SecurityConfiguration.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.filter.ForwardedHeaderFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -15,5 +16,12 @@ public class SecurityConfiguration {
   SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
     httpSecurity.formLogin().disable();
     return httpSecurity.build();
+  }
+
+  @Bean
+  // Use X-Forwarded-For / X-Forwarded-Proto headers when generating full link URLs.
+  public ForwardedHeaderFilter forwardedHeaderFilter() {
+    ForwardedHeaderFilter filter = new ForwardedHeaderFilter();
+    return filter;
   }
 }


### PR DESCRIPTION
There was a bug with the /navigation endpoint: it was navigating to http rather than keeping "https" before the URL.

Let's use this little configuration bean to pick up the X-Forwarded-{For,Proto,Port} headers and use them for URL generation.

ASANA-1204443722442392