### PR TITLE
Add placeholder so form flow builder migrations can succeed

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -55,6 +55,8 @@ spring:
     password:
   flyway:
     out-of-order: true
+    placeholders:
+      uuid_function: "gen_random_uuid"
   servlet:
     multipart:
       max-file-size: ${form-flow.uploads.max-file-size}MB


### PR DESCRIPTION
Before this change, I was getting an error from Flyway when running migrations. After this change, the app's migrations can complete.

See also: https://github.com/search?q=repo%3Acodeforamerica%2Fform-flow%20uuid_function&type=code