### PR TITLE
Add Condition for "hourly wage" page

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
 }
 
 def profile = props.getProperty('SPRING_PROFILES_ACTIVE')
-def formFlowLibraryVersion = '0.0.3-SNAPSHOT'
+def formFlowLibraryVersion = '0.0.4-SNAPSHOT'
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'

--- a/src/main/java/org/homeschoolpebt/app/submission/conditions/IsJobHourly.java
+++ b/src/main/java/org/homeschoolpebt/app/submission/conditions/IsJobHourly.java
@@ -1,0 +1,26 @@
+package org.homeschoolpebt.app.submission.conditions;
+
+import formflow.library.config.submission.Condition;
+import formflow.library.data.Submission;
+import java.util.ArrayList;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IsJobHourly implements Condition {
+  public Boolean run(Submission submission, String uuid) {
+    var item = currentSubflowItem(submission, uuid);
+
+    return item != null && item.getOrDefault("incomeIsJobHourly", "false").equals("true");
+  }
+
+  private Map<String, Object> currentSubflowItem(Submission submission, String uuid) {
+    var inputData = submission.getInputData();
+    var items = (ArrayList<Map<String, Object>>) inputData.getOrDefault("income", new ArrayList<Map<String, Object>>());
+    return items
+        .stream()
+        .filter(item -> item.get("uuid").equals(uuid))
+        .findFirst()
+        .orElse(null);
+  }
+}

--- a/src/main/java/org/homeschoolpebt/app/submission/conditions/PreScreenHasOnlyOneStudent.java
+++ b/src/main/java/org/homeschoolpebt/app/submission/conditions/PreScreenHasOnlyOneStudent.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class PreScreenHasOnlyOneStudent implements Condition {
   @Override
-  public Boolean run(Submission submission) {
+  public Boolean run(Submission submission, String subflowUuid) {
     if (submission.getInputData().containsKey("hasMoreThanOneStudent") && submission.getInputData().containsKey("isApplyingForSelf")) {
       return submission.getInputData().get("hasMoreThanOneStudent").equals("false") &&
           submission.getInputData().get("isApplyingForSelf").equals("false");

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -142,8 +142,7 @@ flow:
     subflow: income
     nextScreens:
       - name: incomeGrossMonthlyIndividual
-      # TODO: Implement this condition when FFL supports conditional pages in sub-flows.
-      # condition: HasMultipleJobsThatArentSelfEmployment
+      # TODO: Implement the self-employment flow and use a condition to go there
   incomeGrossMonthlyIndividual:
     subflow: income
     nextScreens:
@@ -152,10 +151,12 @@ flow:
     subflow: income
     nextScreens:
       - name: incomeHourlyWageCalculator
+        condition: IsJobHourly
+      - name: incomeRegularPayCalculator
   incomeHourlyWageCalculator:
     subflow: income
     nextScreens:
-      - name: incomeRegularPayCalculator
+      - name: incomeWillBeLess
   incomeRegularPayCalculator:
     subflow: income
     nextScreens:

--- a/src/test/java/org/homeschoolpebt/app/journeys/PebtFlowJourneyTest.java
+++ b/src/test/java/org/homeschoolpebt/app/journeys/PebtFlowJourneyTest.java
@@ -1,6 +1,7 @@
 package org.homeschoolpebt.app.journeys;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.homeschoolpebt.app.utils.YesNoAnswer.NO;
 import static org.homeschoolpebt.app.utils.YesNoAnswer.YES;
 
 import java.time.Duration;
@@ -164,6 +165,10 @@ public class PebtFlowJourneyTest extends AbstractBasePageTest {
     testPage.enter("incomeHourlyWage", "10"); // What's [x]'s hourly wage?
     testPage.enter("incomeHoursPerWeek", "40");
     testPage.clickContinue();
+    assertThat(testPage.getTitle()).isEqualTo("Do you think applicant will make less this year?"); // TODO: This should be the applicant's name, not the word "applicant".
+    testPage.goBack();
+    testPage.goBack();
+    testPage.clickButton(NO.getDisplayValue()); // Is this job paid by the hour?
     testPage.findElementById("incomeRegularPayInterval-semimonthly-label").click(); // How does [x] get paid?
     testPage.enter("incomeRegularPayAmount", "1000");
     testPage.clickContinue();


### PR DESCRIPTION
This is the first of some complicated page skipping logic in the income flow, enabled by https://github.com/codeforamerica/form-flow/pull/206.

* Upgrade FFL 0.0.3 -> 0.0.4 to get the change.
* Add condition to only show the "what's your hourly wage" page if you answer that the job is paid hourly.
* Update PreScreenHasOnlyOneStudent method signature since it's used in a subflow and must receive the `subflowUuid` now.
* Test via answering "Yes", then going back, changing to "No", and verifying that we end up on the right page either way.