### PR TITLE
Adjust Gradle config in GitHub Actions

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -34,8 +34,6 @@ jobs:
       - name: Set up ChromeDriver
         uses: nanasess/setup-chromedriver@v1.0.8
       - uses: actions/checkout@v3
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Test with Gradle

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:13
+        image: postgres:13-alpine
         env:
           POSTGRES_USER: starter-app-test
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: starter-app-test
-        options: -c fsync=off -c synchronous_commit=off -c full_page_writes=off --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
         ports:
           - 5432:5432
     steps:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres
+        image: postgres:13
         env:
           POSTGRES_USER: starter-app-test
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: starter-app-test
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5 -c fsync=off -c synchronous_commit=off -c full_page_writes=off
         ports:
           - 5432:5432
     steps:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -22,7 +22,7 @@ jobs:
           POSTGRES_USER: starter-app-test
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: starter-app-test
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5 -c fsync=off -c synchronous_commit=off -c full_page_writes=off
+        options: -c fsync=off -c synchronous_commit=off -c full_page_writes=off --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
         ports:
           - 5432:5432
     steps:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -26,28 +26,20 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up ChromeDriver
-        uses: nanasess/setup-chromedriver@v1.0.8
       - name: Set up JDK
         uses: actions/setup-java@v3.5.0
         with:
           distribution: 'adopt'
           java-version: '17'
-          cache: 'gradle'
+      - name: Set up ChromeDriver
+        uses: nanasess/setup-chromedriver@v1.0.8
+      - uses: actions/checkout@v3
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Test with Gradle
         run: ./gradlew clean test --stacktrace --info
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - name: Announce failures on Slack
         if: ${{ failure() && github.ref == 'main' }}
         uses: ravsamhq/notify-slack-action@v2
@@ -55,7 +47,3 @@ jobs:
           status: ${{ job.status }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      - name: Cleanup Gradle Cache
-        run: |
-          rm -f ~/.gradle/caches/modules-2/modules-2.lock
-          rm -f ~/.gradle/caches/modules-2/gc.properties


### PR DESCRIPTION
Switch to `gradle/gradle-build-action@v2` for Gradle cache, which only saves the cache when doing builds on `main`. This allows pull requests to save about 40 seconds per build, or about 15-20% of the build time.

Also: Change Docker image for Postgres in the hopes it download & starts faster.