### PR TITLE
Add aria-hidden="true" to our icons

### DIFF
--- a/src/main/resources/templates/fragments/icons.html
+++ b/src/main/resources/templates/fragments/icons.html
@@ -32,7 +32,7 @@
     <tr>
       <td>address</td>
       <td>
-        <svg th:fragment="address" width="101" height="75" viewBox="0 0 101 75" fill="none"
+        <svg th:fragment="address" aria-hidden="true" width="101" height="75" viewBox="0 0 101 75" fill="none"
              xmlns="http://www.w3.org/2000/svg">
           <g clip-path="url(#clip0_1044_7640)">
             <path fill-rule="evenodd" clip-rule="evenodd"
@@ -61,7 +61,7 @@
     <tr>
       <td>contactInfo</td>
       <td>
-        <svg th:fragment="contactInfo" width="101" height="75" viewBox="0 0 101 75" fill="none"
+        <svg th:fragment="contactInfo" aria-hidden="true" width="101" height="75" viewBox="0 0 101 75" fill="none"
              xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" clip-rule="evenodd"
                 d="M69.5018 15.29C76.2871 20.9901 83.4648 26.7762 85.2173 35.4793C87.3356 45.9989 87.6347 58.7367 79.709 65.9796C71.8861 73.1286 59.8452 68.6268 49.2747 68.3258C39.2409 68.0401 27.967 71.1072 20.5953 64.2965C13.0928 57.365 13.0617 45.7731 13.8114 35.5617C14.4984 26.2048 17.385 16.7649 24.531 10.6887C31.2419 4.9825 40.6031 4.45129 49.347 5.34594C57.0967 6.13887 63.5374 10.2796 69.5018 15.29Z"
@@ -79,7 +79,7 @@
     <tr>
       <td>deleteDocument</td>
       <td>
-        <svg th:fragment="deleteDocument" width="101" height="75" viewBox="0 0 101 75" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg th:fragment="deleteDocument" aria-hidden="true" width="101" height="75" viewBox="0 0 101 75" fill="none" xmlns="http://www.w3.org/2000/svg">
           <g clip-path="url(#clip0_1755_50991)">
             <path d="M23.5344 65.1458C15.3946 57.3999 12.3656 45.2358 14.9744 35.8996C17.6011 26.5601 24.9418 18.6791 38.4424 13.5186C51.9431 8.35802 49.748 3.08716 61.5046 1.82907C73.2613 0.570977 79.396 7.78825 83.1013 19.0708C86.8066 30.3533 86.5072 41.8282 81.678 51.9501C76.8488 62.0719 67.4899 70.8406 56.1999 73.5403C44.8919 76.2434 31.6774 72.9092 23.5344 65.1458Z" fill="#89CCBB"/>
             <path d="M71.3434 16H27.5993C27.0097 16 26.5481 16.5074 26.6038 17.0944L31.0153 63.6267C31.0635 64.1347 31.4866 64.525 31.9969 64.5322L64.4676 64.9877C64.9694 64.9947 65.3986 64.6288 65.4712 64.1323L72.3329 17.1445C72.421 16.5411 71.9532 16 71.3434 16Z" fill="white"/>
@@ -101,7 +101,7 @@
     <tr>
       <td>documentsSent</td>
       <td>
-        <svg th:fragment="documentsSent" width="101" height="75" viewBox="0 0 101 75" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg th:fragment="documentsSent" aria-hidden="true" width="101" height="75" viewBox="0 0 101 75" fill="none" xmlns="http://www.w3.org/2000/svg">
           <g clip-path="url(#clip0_1606_81324)">
             <path fill-rule="evenodd" clip-rule="evenodd" d="M14.6942 19.1559C19.2915 12.7392 27.1159 10.1374 34.3146 6.81527C41.6607 3.42515 48.8389 -1.07988 56.9112 -0.326675C65.5109 0.475736 73.9515 4.42445 79.4572 11.0274C84.8519 17.4973 85.6029 26.3104 86.1045 34.685C86.5843 42.6953 86.5902 51.0768 82.2617 57.8518C78.0219 64.4882 70.4257 67.8389 63.064 70.7493C55.9719 73.5531 48.5138 75.4395 40.9815 74.1716C33.2201 72.8651 26.1795 69.0576 20.5542 63.5936C14.6421 57.8509 9.66747 50.8455 8.5951 42.7134C7.50795 34.4694 9.84119 25.9294 14.6942 19.1559Z" fill="#89CCBB"/>
             <line x1="4" y1="29.5" x2="23" y2="29.5" stroke="#121111" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
@@ -129,7 +129,7 @@
     <tr>
       <td>error</td>
       <td>
-        <svg th:fragment="error" width="101" height="75" viewBox="0 0 101 75" fill="none"
+        <svg th:fragment="error" aria-hidden="true" width="101" height="75" viewBox="0 0 101 75" fill="none"
              xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" clip-rule="evenodd"
                 d="M20.8394 34.1885C21.7562 24.3159 21.2501 13.4716 28.8499 7.06564C36.6427 0.496993 47.721 0.941252 57.693 3.12395C67.7911 5.33426 77.2589 10.0156 82.5999 18.8306C88.6405 28.8004 92.2489 41.2498 87.1388 51.7228C82.0431 62.1666 69.694 65.4549 58.4142 68.3993C46.4521 71.5219 32.2784 76.7349 23.1521 68.4256C14.2329 60.305 19.7267 46.1714 20.8394 34.1885Z"
@@ -172,7 +172,7 @@
     <tr>
       <td>face</td>
       <td>
-        <svg th:fragment="face" width="101" height="75" viewBox="0 0 101 75" fill="none"
+        <svg th:fragment="face" aria-hidden="true" width="101" height="75" viewBox="0 0 101 75" fill="none"
              xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" clip-rule="evenodd"
                 d="M83.1002 41.0488C82.2017 50.751 82.6977 61.4081 75.2499 67.7036C67.613 74.1589 56.7562 73.7223 46.9837 71.5772C37.0875 69.4051 27.8091 64.8045 22.5749 56.1416C16.6551 46.3439 13.1189 34.1093 18.1267 23.817C23.1206 13.5534 35.2227 10.3218 46.2769 7.42822C57.9998 4.35955 71.89 -0.763551 80.8338 7.40236C89.5745 15.3829 84.1906 29.2726 83.1002 41.0488Z"
@@ -192,7 +192,7 @@
     <tr>
       <td>household</td>
       <td>
-        <svg th:fragment="household" width="101" height="75" viewBox="0 0 101 75" fill="none"
+        <svg th:fragment="household" aria-hidden="true" width="101" height="75" viewBox="0 0 101 75" fill="none"
              xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" clip-rule="evenodd"
                 d="M48.5983 2.72159C61.4095 2.47605 75.9441 -4.44437 85.0801 4.78171C94.7766 14.5739 93.3907 30.8457 89.7806 44.3102C86.3877 56.9644 78.6067 68.4797 66.7129 73.2852C55.6604 77.7508 43.9275 72.7155 33.3863 67.0955C23.3708 61.7557 14.3935 54.5082 10.8546 43.5042C6.84082 31.0241 4.96797 15.6751 13.785 6.14812C22.2343 -2.98141 36.3355 2.95661 48.5983 2.72159Z"
@@ -228,7 +228,7 @@
     <tr>
       <td>mapPathIcons</td>
       <td>
-        <svg th:fragment="mapPathIcons" width="101" height="75" viewBox="0 0 101 75" fill="none"
+        <svg th:fragment="mapPathIcons" aria-hidden="true" width="101" height="75" viewBox="0 0 101 75" fill="none"
              xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" clip-rule="evenodd"
                 d="M85.3813 29.8636C86.9464 36.1882 85.8524 42.6062 84.5654 48.9823C83.1381 56.0533 83.1224 64.4992 77.4922 68.9472C71.8648 73.393 63.6676 70.3243 56.5478 71.117C49.4916 71.9026 42.6607 75.5629 35.8267 73.5863C28.4759 71.4604 21.2187 66.8616 17.8717 59.9312C14.5874 53.1306 18.1892 45.2933 18.5209 37.7519C18.8435 30.421 16.0792 22.5214 19.7947 16.223C23.5554 9.84791 30.9384 6.37637 38.0885 4.58159C44.6558 2.9331 51.2867 5.1607 57.9026 6.65732C64.1707 8.07526 70.7538 8.92375 75.6822 13.0859C80.7088 17.3309 83.7966 23.4597 85.3813 29.8636Z"
@@ -259,7 +259,7 @@
     <tr>
       <td>onePerson</td>
       <td>
-        <svg th:fragment="onePerson" width="101" height="75" viewBox="0 0 101 75" fill="none"
+        <svg th:fragment="onePerson" aria-hidden="true" width="101" height="75" viewBox="0 0 101 75" fill="none"
              xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" clip-rule="evenodd"
                 d="M78.0323 64.0161C71.9547 69.0396 63.7557 69.5292 55.973 70.8791C48.031 72.2566 39.9632 74.7579 32.3906 71.9325C24.3233 68.9224 17.2202 62.9052 13.6252 55.0783C10.1027 47.4091 11.6522 38.6751 13.3286 30.4309C14.9321 22.5451 17.0872 14.4229 22.9985 8.98227C28.7887 3.65303 36.9612 2.37867 44.7946 1.47002C52.341 0.59466 60.0031 0.703132 66.9234 3.88711C74.0542 7.16795 79.8467 12.6848 83.8504 19.4393C88.0582 26.5382 91.0384 34.6172 89.9737 42.7747C88.8944 51.0446 84.4478 58.7131 78.0323 64.0161Z"
@@ -284,7 +284,7 @@
     <tr>
       <td>people</td>
       <td>
-        <svg th:fragment="people" width="101" height="75" viewBox="0 0 101 75" fill="none"
+        <svg th:fragment="people" aria-hidden="true" width="101" height="75" viewBox="0 0 101 75" fill="none"
              xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" clip-rule="evenodd"
                 d="M75.2937 65.823C69.1923 70.8312 60.9611 71.3192 53.1478 72.665C45.1746 74.0383 37.0751 76.532 29.4728 73.7152C21.3738 70.7143 14.2427 64.7156 10.6336 56.9126C7.09725 49.2669 8.65286 40.5597 10.3358 32.3407C11.9457 24.4791 14.1093 16.3818 20.0437 10.9578C25.8567 5.6449 34.0613 4.37445 41.9254 3.46858C49.5015 2.5959 57.1937 2.70404 64.1412 5.87827C71.3 9.14906 77.1153 14.649 81.1347 21.3828C85.3591 28.46 88.351 36.5142 87.2821 44.6467C86.1985 52.8912 81.7345 60.5363 75.2937 65.823Z"
@@ -315,7 +315,7 @@
     <tr>
       <td>person</td>
       <td>
-        <svg th:fragment="person" width="101" height="75" viewBox="0 0 101 75" fill="none"
+        <svg th:fragment="person" aria-hidden="true" width="101" height="75" viewBox="0 0 101 75" fill="none"
              xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" clip-rule="evenodd"
                 d="M82.8614 41.0488C81.963 50.751 82.4589 61.4081 75.0111 67.7036C67.3742 74.1589 56.5174 73.7223 46.7449 71.5772C36.8488 69.4051 27.5703 64.8045 22.3361 56.1416C16.4163 46.3439 12.8802 34.1093 17.888 23.817C22.8818 13.5534 34.9839 10.3218 46.0381 7.42822C57.761 4.35955 71.6512 -0.763551 80.595 7.40236C89.3358 15.3829 83.9519 29.2726 82.8614 41.0488Z"
@@ -332,7 +332,7 @@
     <tr>
       <td>personWithDollarSign</td>
       <td>
-        <svg th:fragment="personWithDollarSign" width="101" height="75" viewBox="0 0 101 75"
+        <svg th:fragment="personWithDollarSign" aria-hidden="true" width="101" height="75" viewBox="0 0 101 75"
              fill="none" xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" clip-rule="evenodd"
                 d="M78.0323 64.0161C71.9547 69.0396 63.7557 69.5292 55.973 70.8791C48.031 72.2566 39.9632 74.7579 32.3906 71.9325C24.3233 68.9224 17.2202 62.9052 13.6252 55.0783C10.1027 47.4091 11.6522 38.6751 13.3286 30.4309C14.9321 22.5451 17.0872 14.4229 22.9985 8.98227C28.7887 3.65303 36.9612 2.37867 44.7946 1.47002C52.341 0.59466 60.0031 0.703132 66.9234 3.88711C74.0542 7.16795 79.8467 12.6848 83.8504 19.4393C88.0582 26.5382 91.0384 34.6172 89.9737 42.7747C88.8944 51.0446 84.4478 58.7131 78.0323 64.0161Z"
@@ -360,7 +360,7 @@
     <tr>
       <td>prepareToApply</td>
       <td>
-        <svg th:fragment="prepareToApply" width="101" height="75" viewBox="0 0 101 75" fill="none"
+        <svg th:fragment="prepareToApply" aria-hidden="true" width="101" height="75" viewBox="0 0 101 75" fill="none"
              xmlns="http://www.w3.org/2000/svg">
           <g clip-path="url(#clip0_1051_5441)">
             <path fill-rule="evenodd" clip-rule="evenodd"
@@ -398,7 +398,7 @@
     <tr>
       <td>school</td>
       <td>
-        <svg th:fragment="school" width="101" height="75" viewBox="0 0 101 75" fill="none"
+        <svg th:fragment="school" aria-hidden="true" width="101" height="75" viewBox="0 0 101 75" fill="none"
              xmlns="http://www.w3.org/2000/svg">
           <g clip-path="url(#clip0_1188_6243)">
             <path fill-rule="evenodd" clip-rule="evenodd"
@@ -430,7 +430,7 @@
     <tr>
       <td>success</td>
       <td>
-        <svg th:fragment="success" width="101" height="75" viewBox="0 0 101 75" fill="none"
+        <svg th:fragment="success" aria-hidden="true" width="101" height="75" viewBox="0 0 101 75" fill="none"
              xmlns="http://www.w3.org/2000/svg">
           <g clip-path="url(#clip0_1199_21520)">
             <path fill-rule="evenodd" clip-rule="evenodd"
@@ -451,7 +451,7 @@
     <tr>
       <td>documentsSearch</td>
       <td>
-        <svg th:fragment="documentsSearch" width="101" height="75" viewBox="0 0 101 75" fill="none"
+        <svg th:fragment="documentsSearch" aria-hidden="true" width="101" height="75" viewBox="0 0 101 75" fill="none"
              xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" clip-rule="evenodd"
                 d="M49.3641 69.286C39.3847 68.3619 28.4231 68.872 21.9478 61.2114C15.308 53.3563 15.7571 42.1893 17.9634 32.1376C20.1976 21.9587 24.9296 12.4152 33.8401 7.03147C43.9177 0.942532 56.5019 -2.69467 67.0883 2.45622C77.6451 7.59275 80.969 20.0406 83.9453 31.4106C87.1016 43.4685 92.3711 57.7555 83.9719 66.9549C75.7633 75.9454 61.4768 70.4076 49.3641 69.286Z"
@@ -489,7 +489,7 @@
     <tr>
       <td>clipboardWithEnvelope</td>
       <td>
-        <svg th:fragment="clipboardWithEnvelope" width="101" height="75" viewBox="0 0 101 75"
+        <svg th:fragment="clipboardWithEnvelope" aria-hidden="true" width="101" height="75" viewBox="0 0 101 75"
              fill="none" xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" clip-rule="evenodd"
                 d="M32.2903 68.5636C26.1328 65.5239 19.3046 62.8861 15.736 57.0167C12.0774 50.9991 12.2464 43.5404 12.8045 36.5141C13.3699 29.3947 14.4287 21.9642 18.9587 16.4407C23.4519 10.962 30.5411 8.67831 37.3178 6.62433C43.8713 4.638 50.7714 2.94211 57.3569 4.80237C63.8329 6.63166 68.8052 11.58 73.1264 16.7393C77.2393 21.6498 79.8154 27.4265 81.488 33.6133C83.2726 40.2142 85.2862 47.1658 83.1057 53.6515C80.8788 60.2755 75.4793 65.3811 69.5602 69.0926C63.854 72.6706 57.1564 74.2377 50.4271 74.1422C43.9701 74.0505 38.0788 71.4211 32.2903 68.5636Z"
@@ -532,7 +532,7 @@
     <tr>
       <td>householdYellow</td>
       <td>
-        <svg th:fragment="householdYellow" width="101" height="75" viewBox="0 0 101 75" fill="none"
+        <svg th:fragment="householdYellow" aria-hidden="true" width="101" height="75" viewBox="0 0 101 75" fill="none"
              xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" clip-rule="evenodd"
                 d="M50.5555 0.00771481C57.3164 0.130754 63.4565 2.80303 69.5028 5.64798C76.208 8.80294 84.6708 10.9671 87.6176 17.4463C90.5629 23.9221 85.2845 30.9264 84.1667 37.89C83.0589 44.7915 84.8933 52.2104 81.0762 58.1979C76.9704 64.6382 70.4107 70.3604 62.5639 71.7754C54.8641 73.164 47.9747 67.7489 40.5037 65.5146C33.2411 63.3428 24.5792 63.9578 19.2631 58.8263C13.8823 53.6322 12.3853 45.7369 12.5067 38.4895C12.6182 31.8328 16.6326 26.1021 19.9101 20.1996C23.0153 14.6074 25.6342 8.57113 31.1306 4.94965C36.7364 1.25605 43.71 -0.116865 50.5555 0.00771481Z"
@@ -588,7 +588,7 @@
         cash
       </td>
       <td>
-        <svg th:fragment="cash" width="101" height="75" viewBox="0 0 101 75" fill="none"
+        <svg th:fragment="cash" aria-hidden="true" width="101" height="75" viewBox="0 0 101 75" fill="none"
              xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" clip-rule="evenodd"
                 d="M38.2178 67.3012C28.6923 64.6718 17.9663 63.2429 13.003 54.7808C7.91363 46.1038 10.2748 35.4976 14.1492 26.2658C18.0725 16.9173 24.3102 8.61347 33.8859 5.02054C44.7159 0.956967 57.5557 -0.322415 66.9414 6.45738C76.301 13.2183 77.3805 25.7098 78.3086 37.1093C79.2927 49.1984 81.9433 63.7899 72.2059 71.1231C62.6895 78.2897 49.7795 70.4927 38.2178 67.3012Z"
@@ -639,7 +639,7 @@
         smallPlus
       </td>
       <td>
-        <svg th:fragment="smallPlus" width="16" height="15" viewBox="0 0 16 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg th:fragment="smallPlus" aria-hidden="true" width="16" height="15" viewBox="0 0 16 15" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M15.2923 8.54036H9.04232V14.7904H6.95898V8.54036H0.708984V6.45703H6.95898V0.207031H9.04232V6.45703H15.2923V8.54036Z" fill="white"/>
         </svg>
       </td>
@@ -647,7 +647,7 @@
     <tr>
       <td>personIncome</td>
       <td>
-        <svg th:fragment="personIncome" width="101" height="76" viewBox="0 0 101 76" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg th:fragment="personIncome" aria-hidden="true" width="101" height="76" viewBox="0 0 101 76" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" clip-rule="evenodd" d="M78.0323 64.0981C71.9547 69.1217 63.7557 69.6112 55.973 70.9611C48.031 72.3386 39.9632 74.84 32.3906 72.0145C24.3233 69.0044 17.2202 62.9872 13.6252 55.1603C10.1027 47.4911 11.6522 38.7572 13.3286 30.5129C14.9321 22.6271 17.0872 14.5049 22.9985 9.0643C28.7887 3.73506 36.9612 2.4607 44.7946 1.55206C52.341 0.676692 60.0031 0.785163 66.9234 3.96914C74.0542 7.24998 79.8467 12.7668 83.8504 19.5213C88.0582 26.6203 91.0384 34.6993 89.9737 42.8568C88.8944 51.1266 84.4478 58.7951 78.0323 64.0981Z" fill="#89CCBB"/>
           <path d="M44.0065 31.0655C37.1046 31.0655 31.5 36.6541 31.5 43.5654V62.082H56.5V43.5654C56.513 36.6671 50.9214 31.0655 44.0065 31.0655Z" fill="#FFEAF6"/>
           <path d="M44.0065 31.0655C49.2513 31.0655 53.5032 26.8158 53.5032 21.5737C53.5032 16.3316 49.2513 12.082 44.0065 12.082C38.7616 12.082 34.5099 16.3316 34.5099 21.5737C34.5099 26.8158 38.7617 31.0655 44.0065 31.0655Z" fill="#FFEAF6"/>
@@ -663,7 +663,7 @@
         briefcaseGreen
       </td>
       <td>
-        <svg th:fragment="briefcaseGreen" width="101" height="76" viewBox="0 0 101 76" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg th:fragment="briefcaseGreen" aria-hidden="true" width="101" height="76" viewBox="0 0 101 76" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" clip-rule="evenodd" d="M71.5714 13.0365C78.7285 19.0874 86.2995 25.2296 88.1481 34.4683C90.3825 45.6352 90.6979 59.1568 82.338 66.8455C74.0864 74.4344 61.3857 69.6555 50.2359 69.3361C39.6524 69.0328 27.7608 72.2886 19.9851 65.0588C12.0715 57.7007 12.0388 45.3955 12.8295 34.5557C13.5541 24.623 16.5989 14.6022 24.1365 8.15209C31.2151 2.09471 41.0892 1.53081 50.3122 2.48051C58.4866 3.32224 65.2802 7.71774 71.5714 13.0365Z" fill="#89CCBB"/>
           <rect x="22" y="26.6133" width="56" height="33" rx="2.5" fill="#EEFFE6" stroke="#121111" stroke-width="3"/>
           <path d="M39.5 25.1133V20.1133C39.5 18.4564 40.8431 17.1133 42.5 17.1133H58.5C60.1569 17.1133 61.5 18.4564 61.5 20.1133V25.1133" stroke="#121111" stroke-width="3"/>
@@ -675,7 +675,7 @@
         moneyTips
       </td>
       <td>
-        <svg th:fragment="moneyTips" width="101" height="75" viewBox="0 0 101 75" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg th:fragment="moneyTips" aria-hidden="true" width="101" height="75" viewBox="0 0 101 75" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" clip-rule="evenodd" d="M83.459 39.0488C82.5606 48.751 83.0566 59.4081 75.6088 65.7036C67.9719 72.1589 57.1151 71.7223 47.3425 69.5772C37.4464 67.4051 28.168 62.8045 22.9338 54.1416C17.014 44.3439 13.4778 32.1093 18.4856 21.817C23.4795 11.5534 35.5816 8.32183 46.6358 5.42822C58.3587 2.35955 72.2489 -2.76355 81.1927 5.40236C89.9334 13.3829 84.5495 27.2726 83.459 39.0488Z" fill="#89CCBB"/>
           <path d="M32.8636 5L21.0977 33.08L67.8317 52.4163L79.5976 24.3363L32.8636 5Z" fill="#7AC943" stroke="#121111" stroke-width="2" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
           <path d="M56.7582 30.9184C56.0341 32.6453 54.6765 33.9935 52.9375 34.7061C51.1855 35.4187 49.2784 35.4187 47.5393 34.6932C43.9514 33.2103 42.2447 29.0952 43.738 25.5258C44.5009 23.7154 45.9425 22.3801 47.6492 21.7061C49.2978 21.0577 51.192 21.0192 52.9569 21.751C54.6959 22.47 56.0535 23.8182 56.7711 25.5515C57.4887 27.2912 57.4822 29.1979 56.7582 30.9184Z" stroke="#121111" stroke-width="3" stroke-miterlimit="10"/>


### PR DESCRIPTION
The FFL icons all have this. Presumably it's so that screen readers skip them. Let's add it to all of our icons as well.