### PR TITLE
Remove Mailgun dependency in favor of form-flow depending on it

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,6 @@ dependencies {
 
     implementation 'org.flywaydb:flyway-core'
 
-    implementation 'com.mailgun:mailgun-java:1.0.7'
-
     implementation 'io.sentry:sentry-spring-boot-starter:6.17.0'
 
     implementation group: 'org.webjars', name: 'jquery-ui', version: '1.12.1'


### PR DESCRIPTION
This allows the app to launch in dev mode on my workstation. Error message was:


```
***************************
APPLICATION FAILED TO START
***************************

Description:

An attempt was made to call a method that does not exist. The attempt was made from the following location:

    org.homeschoolpebt.app.submission.emails.MailGunEmailClient.<init>(MailGunEmailClient.java:29)

The following method did not exist:

    'com.mailgun.api.MailgunApi com.mailgun.client.MailgunClient$MailgunClientBuilder.createApi(java.lang.Class)'

The calling method's class, org.homeschoolpebt.app.submission.emails.MailGunEmailClient, was loaded from the following location:

    file:/Users/asheesh/projects/homeschool-pebt/build/classes/java/main/org/homeschoolpebt/app/submission/emails/MailGunEmailClient.class

The called method's class, com.mailgun.client.MailgunClient$MailgunClientBuilder, is available from the following locations:

    jar:file:/Users/asheesh/.gradle/caches/modules-2/files-2.1/org.codeforamerica.platform/form-flow/0.0.5-SNAPSHOT/767f49efec903517cb330b24809a04a3a70df471/form-flow-0.0.5-SNAPSHOT-plain.jar!/com/mailgun/client/MailgunClient$MailgunClientBuilder.class
    jar:file:/Users/asheesh/.gradle/caches/modules-2/files-2.1/com.mailgun/mailgun-java/1.0.7/3c84bc6bef93aae8726aa273dd76753ded18cad9/mailgun-java-1.0.7.jar!/com/mailgun/client/MailgunClient$MailgunClientBuilder.class

The called method's class hierarchy was loaded from the following locations:

    com.mailgun.client.MailgunClient.MailgunClientBuilder: file:/Users/asheesh/.gradle/caches/modules-2/files-2.1/org.codeforamerica.platform/form-flow/0.0.5-SNAPSHOT/767f49efec903517cb330b24809a04a3a70df471/form-flow-0.0.5-SNAPSHOT-plain.jar
```