### PR TITLE
Rewrite uploadFile test helper to maybe be more reliable?

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,6 +29,8 @@ form-flow:
       sender-email: noreply@${MAILGUN_DOMAIN}
       key: ${MAILGUN_API_KEY}
       domain: ${MAILGUN_DOMAIN}
+  # This key is for testing only, as it is committed to the repo for testing!
+  encryption-key: '{"primaryKeyId":2135185311,"key":[{"keyData":{"typeUrl":"type.googleapis.com/google.crypto.tink.AesGcmKey","value":"GiCRKaXiJ/zlDHAZfRQf1rCIbIY4fFmLqLWYIPLNXpOx4A==","keyMaterialType":"SYMMETRIC"},"status":"ENABLED","keyId":2135185311,"outputPrefixType":"TINK"}]}"'
 spring:
   profiles:
     group:

--- a/src/test/java/org/homeschoolpebt/app/journeys/PebtFlowJourneyTest.java
+++ b/src/test/java/org/homeschoolpebt/app/journeys/PebtFlowJourneyTest.java
@@ -202,7 +202,8 @@ public class PebtFlowJourneyTest extends AbstractBasePageTest {
     testPage.clickContinue();
 
     testPage.clickLink("Next step"); // Done (with income)! Let's get your application submitted.
-    testPage.clickButton("Submit"); // Has anybody in your household experienced economic hardship as a result of the COVID-19 pandemic?
+    testPage.clickElementById("economicHardshipTypes-Furloughed due to COVID-19"); // Has anybody in your household experienced economic hardship as a result of the COVID-19 pandemic?
+    testPage.clickButton("Submit");
 
     // Document Uploader
     assertThat(testPage.getTitle()).isEqualTo("Adding Documents");

--- a/src/test/java/org/homeschoolpebt/app/utils/AbstractBasePageTest.java
+++ b/src/test/java/org/homeschoolpebt/app/utils/AbstractBasePageTest.java
@@ -1,25 +1,29 @@
 package org.homeschoolpebt.app.utils;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import org.junit.jupiter.api.BeforeEach;
 import org.openqa.selenium.By;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @Import({WebDriverConfiguration.class})
@@ -65,12 +69,18 @@ public abstract class AbstractBasePageTest {
   }
 
   protected void uploadFile(String filepath, String dzName) {
-    testPage.clickElementById("drag-and-drop-box-" + dzName); // is this needed?
-    WebElement upload = driver.findElement(By.className("dz-hidden-input"));
+    var hiddenInputSelector = By.className("dz-hidden-input");
+    new WebDriverWait(driver, Duration.ofSeconds(1)).until(
+      ExpectedConditions.presenceOfElementLocated(hiddenInputSelector)
+    );
+    WebElement upload = driver.findElement(hiddenInputSelector);
+
     upload.sendKeys(TestUtils.getAbsoluteFilepathString(filepath));
-    await().until(
-        () -> !driver.findElements(By.className("file-details")).get(0).getAttribute("innerHTML")
-            .isBlank());
+
+    var fileDetailsSelector = By.className("file-details");
+    new WebDriverWait(driver, Duration.ofSeconds(1)).until(
+      ExpectedConditions.textMatches(fileDetailsSelector, Pattern.compile("delete"))
+    );
   }
 
   protected void uploadJpgFile(String dzName) {

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -17,6 +17,7 @@ form-flow:
       sender-email: hello@test.com
       key: 1234
       domain: test.com
+  encryption-key: '{"primaryKeyId":2135185311,"key":[{"keyData":{"typeUrl":"type.googleapis.com/google.crypto.tink.AesGcmKey","value":"GiCRKaXiJ/zlDHAZfRQf1rCIbIY4fFmLqLWYIPLNXpOx4A==","keyMaterialType":"SYMMETRIC"},"status":"ENABLED","keyId":2135185311,"outputPrefixType":"TINK"}]}"'
 spring:
   datasource:
     url: jdbc:postgresql://localhost:5432/starter-app-test


### PR DESCRIPTION
It's been failing. This rewrites it to use Selenium waits rather than the awaitility library. This should tolerate the elements being a bit slower, since it won't raise if the element isn't present upon the first execution of the wait condition.