### PR TITLE
Store sessions in the database

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.session:spring-session-jdbc'
     implementation 'org.springframework.shell:spring-shell-starter:3.0.4'
 
     implementation 'org.flywaydb:flyway-core'

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -42,6 +42,11 @@ spring:
       demo:
         - demo
         - form-flow-library
+  session:
+    store-type: jdbc
+    timeout: 72h
+    jdbc:
+      initialize-schema: always
   thymeleaf:
     cache: false
     template-resolver-order: 0


### PR DESCRIPTION
Database-backed sessions are necessary to persist user data across container restarts. This should be a nice change for dev as well as being necessary in demo/prod.

It seems like the spring-session-jdbc library manages the schema and everything.