### PR TITLE
Allow skipping app doc upload screens

### DIFF
--- a/src/main/java/org/homeschoolpebt/app/submission/conditions/MissingAnyDocumentUploads.java
+++ b/src/main/java/org/homeschoolpebt/app/submission/conditions/MissingAnyDocumentUploads.java
@@ -1,0 +1,16 @@
+package org.homeschoolpebt.app.submission.conditions;
+
+import formflow.library.config.submission.Condition;
+import formflow.library.data.Submission;
+import org.homeschoolpebt.app.utils.SubmissionUtilities;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MissingAnyDocumentUploads implements Condition {
+
+  public Boolean run(Submission submission) {
+    var missingDocTypes = SubmissionUtilities.getMissingDocUploads(submission);
+
+    return missingDocTypes.size() > 0;
+  }
+}

--- a/src/main/java/org/homeschoolpebt/app/submission/conditions/NeedsIncomeVerification.java
+++ b/src/main/java/org/homeschoolpebt/app/submission/conditions/NeedsIncomeVerification.java
@@ -6,9 +6,9 @@ import org.homeschoolpebt.app.utils.SubmissionUtilities;
 import org.springframework.stereotype.Component;
 
 @Component
-public class SkipIncomeVerification implements Condition {
+public class NeedsIncomeVerification implements Condition {
   @Override
   public Boolean run(Submission submission) {
-    return SubmissionUtilities.canSkipIncomeSections(submission);
+    return SubmissionUtilities.needsIncomeVerification(submission);
   }
 }

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -116,9 +116,9 @@ flow:
     nextScreens:
       - name: signpostHouseholdDetails
         condition: HasHousehold
-      - name: addingDocuments
-        condition: SkipIncomeVerification
       - name: signpostIncome
+        condition: NeedsIncomeVerification
+      - name: addingDocuments
   signpostHouseholdDetails:
     nextScreens:
       - name: housemateInfo
@@ -131,9 +131,9 @@ flow:
       - name: householdReceivesBenefits
   householdReceivesBenefits:
     nextScreens:
-      - name: addingDocuments
-        condition: SkipIncomeVerification
       - name: signpostIncome
+        condition: NeedsIncomeVerification
+      - name: addingDocuments
     onPostAction: ClearOtherCaseNumberFields
     crossFieldValidationAction: FDPIRCaseNumberValidationAction
   householdDeleteConfirmation:
@@ -242,19 +242,32 @@ flow:
       - name: uploadEnrollmentDocuments
         condition: NeedsEnrollmentDocs
       - name: uploadIncomeDocuments
+        condition: NeedsIncomeVerification
+      - name: docPendingConfirmation
+        condition: MissingAnyDocumentUploads
+      - name: docSubmitConfirmation
   uploadEnrollmentDocuments:
     nextScreens:
-      - name: docSubmitConfirmation
-        condition: SkipIncomeVerification
       - name: uploadIncomeDocuments
+        condition: NeedsIncomeVerification
+      - name: docPendingConfirmation
+        condition: MissingAnyDocumentUploads
+      - name: docSubmitConfirmation
   uploadIncomeDocuments:
     nextScreens:
       - name: uploadUnearnedIncomeDocuments
         condition: NeedsUnearnedIncomeDocs
+      - name: docPendingConfirmation
+        condition: MissingAnyDocumentUploads
       - name: docSubmitConfirmation
   uploadUnearnedIncomeDocuments:
     nextScreens:
+      - name: docPendingConfirmation
+        condition: MissingAnyDocumentUploads
       - name: docSubmitConfirmation
+  docPendingConfirmation:
+    nextScreens:
+      - name: submitting
   docSubmitConfirmation:
     nextScreens:
       - name: submitting

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -632,3 +632,8 @@ upload-unearned-income-documents.title=Add proof for other income sources
 validation.application-number-format=Application Number must be a 7-digit number.
 validations.make-sure-to-provide-a-first-name=Make sure to provide a first name.
 validations.test=This is just a test.
+adding-documents.you-can-do-it-later=<b>You don''t need all these documents to get started.</b><br>Add what you have now, and then go to <a href="/docs" target="_blank">GetPEBT.org/docs</a> by {0} to submit the rest.
+adding-documents.ill-do-this-later=I'll do this later
+doc-pending-confirmation.title=We'll need the rest of your documents.
+doc-pending-confirmation.youll-still-need=You'll still need:
+doc-pending-confirmation.laterdocs-instructions=You can go to <a href="/docs" target="_blank">GetPEBT.org/docs</a> by {0} to submit these documents later.

--- a/src/main/resources/templates/pebt/addingDocuments.html
+++ b/src/main/resources/templates/pebt/addingDocuments.html
@@ -19,11 +19,21 @@
           <ol class="list--numbered">
             <li th:text="#{adding-documents.students-identity}"></li>
             <li th:text="#{adding-documents.students-enrollment}"></li>
-            <li th:text="#{adding-documents.income-proof}" th:if="${!T(org.homeschoolpebt.app.utils.SubmissionUtilities).canSkipIncomeSections(submission)}"></li>
+            <li th:text="#{adding-documents.income-proof}" th:if="${T(org.homeschoolpebt.app.utils.SubmissionUtilities).needsIncomeVerification(submission)}"></li>
           </ol>
         </div>
+
+        <th:block th:with="deadline=${T(org.homeschoolpebt.app.utils.SubmissionUtilities).getLaterdocDeadline(#dates.createNow())}">
+          <div class="notice notice--success" th:utext="#{adding-documents.you-can-do-it-later(${deadline})}"></div>
+        </th:block>
+
         <div class="form-card__footer text--centered">
-          <th:block th:replace="~{'fragments/continueButton' :: continue(text=#{adding-documents.button})}" />
+          <dIv class="spacing-below-35">
+            <th:block th:replace="~{'fragments/continueButton' :: continue(text=#{adding-documents.button})}" />
+          </div>
+          <div>
+            <a href="/flow/pebt/docPendingConfirmation" th:text="#{adding-documents.ill-do-this-later}"></a>
+          </div>
         </div>
       </main>
     </div>

--- a/src/main/resources/templates/pebt/docPendingConfirmation.html
+++ b/src/main/resources/templates/pebt/docPendingConfirmation.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html th:lang="${#locale.language}">
+<head th:replace="~{fragments/head :: head(title=#{doc-pending-confirmation.title})}"></head>
+<body>
+<div class="page-wrapper">
+  <div th:replace="~{fragments/toolbar :: toolbar}"></div>
+  <section class="slab">
+    <div class="grid">
+      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
+
+      <main id="content" role="main" class="form-card spacing-above-35">
+        <div class="text--centered">
+          <th:block th:replace="~{'fragments/icons' :: success}"></th:block>
+          <th:block th:replace="~{'fragments/cardHeader' :: cardHeader(header=#{doc-pending-confirmation.title})}"/>
+        </div>
+        
+        <div class="form-card__content">
+          <p th:text="#{doc-pending-confirmation.youll-still-need}"></p>
+
+          <th:block th:with="missingDocs=${T(org.homeschoolpebt.app.utils.SubmissionUtilities).getMissingDocUploads(submission)}">
+            <ul class="list--bulleted">
+              <li th:if="${#arrays.contains(missingDocs, 'identity')}" th:text="#{adding-documents.students-identity}"></li>
+              <li th:if="${#arrays.contains(missingDocs, 'enrollment')}" th:text="#{adding-documents.students-enrollment}"></li>
+              <li th:if="${#arrays.contains(missingDocs, 'income')}" th:text="#{adding-documents.income-proof}"></li>
+            </ul>
+          </th:block>
+
+          <th:block th:with="deadline=${T(org.homeschoolpebt.app.utils.SubmissionUtilities).getLaterdocDeadline(#dates.createNow())}">
+            <p th:utext="#{doc-pending-confirmation.laterdocs-instructions(${deadline})}"></p>
+          </th:block>
+        </div>
+        <div class="form-card__footer">
+          <th:block th:replace="~{'fragments/continueButton' :: continue(text=#{general.inputs.continue})}" />
+        </div>
+      </main>
+    </div>
+  </section>
+</div>
+<th:block th:replace="~{fragments/footer :: footer}"/>
+</body>
+</html>

--- a/src/main/resources/templates/pebt/signpostIncome.html
+++ b/src/main/resources/templates/pebt/signpostIncome.html
@@ -11,8 +11,7 @@
         <div class="text--centered">
           <th:block th:replace="~{'fragments/icons' :: householdYellow}"></th:block>
           <p class="text--grey-dark" th:text="#{signpost-income.step}"></p>
-          <th:block
-              th:replace="~{'fragments/cardHeader' :: cardHeader(header=#{signpost-income.title}, subtext=#{signpost-income.subtext})}"/>
+          <th:block th:replace="~{'fragments/cardHeader' :: cardHeader(header=#{signpost-income.title}, subtext=#{signpost-income.subtext})}"/>
         </div>
         <div class="form-card__content">
           <div class="boxed-content">

--- a/src/main/resources/templates/pebt/uploadEnrollmentDocuments.html
+++ b/src/main/resources/templates/pebt/uploadEnrollmentDocuments.html
@@ -41,8 +41,13 @@
             <div class="form-card__content">
               <th:block th:replace="~{fragments/fileUploader :: fileUploader(inputName='enrollmentFiles')}"></th:block>
             </div>
-            <div class="form-card__footer" id="submit">
-              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+            <div class="form-card__footer">
+              <div class="spacing-below-35">
+                <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue}, classes='button button--primary display-none')}"/>
+              </div>
+              <div>
+                <a th:href="'/flow/' + ${flow} + '/' + ${screen} + '/navigation'">Skip</a>
+              </div>
             </div>
           </th:block>
         </th:block>
@@ -51,5 +56,10 @@
   </section>
 </div>
 <th:block th:replace="~{fragments/footer :: footer}"/>
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    FormFlowDZ.hideContinueIfNoFiles('enrollmentFiles', 'form-submit-button');
+  });
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/pebt/uploadIdentityDocuments.html
+++ b/src/main/resources/templates/pebt/uploadIdentityDocuments.html
@@ -41,8 +41,13 @@
             <div class="form-card__content">
               <th:block th:replace="~{fragments/fileUploader :: fileUploader(inputName='identityFiles')}"></th:block>
             </div>
-            <div class="form-card__footer" id="submit">
-              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+            <div class="form-card__footer">
+              <div class="spacing-below-35">
+                <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue}, classes='button button--primary display-none')}"/>
+              </div>
+              <div>
+                <a th:href="'/flow/' + ${flow} + '/' + ${screen} + '/navigation'">Skip</a>
+              </div>
             </div>
           </th:block>
         </th:block>
@@ -51,5 +56,10 @@
   </section>
 </div>
 <th:block th:replace="~{fragments/footer :: footer}"/>
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    FormFlowDZ.hideContinueIfNoFiles('identityFiles', 'form-submit-button');
+  });
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/pebt/uploadIncomeDocuments.html
+++ b/src/main/resources/templates/pebt/uploadIncomeDocuments.html
@@ -49,8 +49,13 @@
             <div class="form-card__content">
               <th:block th:replace="~{fragments/fileUploader :: fileUploader(inputName='incomeFiles')}"></th:block>
             </div>
-            <div class="form-card__footer" id="submit">
-              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+            <div class="form-card__footer">
+              <div class="spacing-below-35">
+                <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue}, classes='button button--primary display-none')}"/>
+              </div>
+              <div>
+                <a th:href="'/flow/' + ${flow} + '/' + ${screen} + '/navigation'">Skip</a>
+              </div>
             </div>
           </th:block>
         </th:block>
@@ -59,5 +64,10 @@
   </section>
 </div>
 <th:block th:replace="~{fragments/footer :: footer}"/>
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    FormFlowDZ.hideContinueIfNoFiles('incomeFiles', 'form-submit-button');
+  });
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/pebt/uploadUnearnedIncomeDocuments.html
+++ b/src/main/resources/templates/pebt/uploadUnearnedIncomeDocuments.html
@@ -29,8 +29,13 @@
             <div class="form-card__content">
               <th:block th:replace="~{fragments/fileUploader :: fileUploader(inputName='unearnedIncomeFiles')}"></th:block>
             </div>
-            <div class="form-card__footer" id="submit">
-              <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
+            <div class="form-card__footer">
+              <div class="spacing-below-35">
+                <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue}, classes='button button--primary display-none')}"/>
+              </div>
+              <div>
+                <a th:href="'/flow/' + ${flow} + '/' + ${screen} + '/navigation'">Skip</a>
+              </div>
             </div>
           </th:block>
         </th:block>
@@ -39,5 +44,10 @@
   </section>
 </div>
 <th:block th:replace="~{fragments/footer :: footer}"/>
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    FormFlowDZ.hideContinueIfNoFiles('unearnedIncomeFiles', 'form-submit-button');
+  });
+</script>
 </body>
 </html>

--- a/src/test/java/org/homeschoolpebt/app/data/TransmissionRepositoryServiceTest.java
+++ b/src/test/java/org/homeschoolpebt/app/data/TransmissionRepositoryServiceTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles("test")
 @SpringBootTest
-class TransmissionRepositoryServiceTest {
+class TransmissionReposItoryServiceTest {
   @Autowired
   private SubmissionRepositoryService submissionRepositoryService;
 

--- a/src/test/java/org/homeschoolpebt/app/utils/AbstractBasePageTest.java
+++ b/src/test/java/org/homeschoolpebt/app/utils/AbstractBasePageTest.java
@@ -91,6 +91,11 @@ public abstract class AbstractBasePageTest {
 
   protected void uploadJpgFile(String dzName) {
     uploadFile(UPLOADED_JPG_FILE_NAME, dzName);
+
+    // wait for upload to complete
+    new WebDriverWait(driver, Duration.ofSeconds(3))
+      .until(ExpectedConditions.javaScriptThrowsNoExceptions("if (!window[\"isUploadComplete" + dzName + "\"]) { throw new Exception(\"upload incomplete\"); }"));
+
     assertThat(driver.findElement(By.id("dropzone-" + dzName)).getText().replace("\n", ""))
         .contains(UPLOADED_JPG_FILE_NAME);
   }

--- a/src/test/java/org/homeschoolpebt/app/utils/SubmissionUtilitiesTest.java
+++ b/src/test/java/org/homeschoolpebt/app/utils/SubmissionUtilitiesTest.java
@@ -1,6 +1,7 @@
 package org.homeschoolpebt.app.utils;
 
 import formflow.library.data.Submission;
+import org.joda.time.DateTime;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -631,7 +632,7 @@ class SubmissionUtilitiesTest {
   @Nested
   class SkipIncomeTests {
     @Test
-    void falseByDefault() {
+    void trueByDefault() {
       var student1 = new HashMap<String, Object>() {{
         put("studentFirstName", "Sally");
         put("studentMiddleInitial", "A");
@@ -653,11 +654,11 @@ class SubmissionUtilitiesTest {
         Map.entry("students", List.of(student1, student2))
       )).build();
 
-      assertThat(SubmissionUtilities.canSkipIncomeSections(submission)).isFalse();
+      assertThat(SubmissionUtilities.needsIncomeVerification(submission)).isTrue();
     }
 
     @Test
-    void trueWhenAllStudentsHaveDesignation() {
+    void falseWhenAllStudentsHaveDesignation() {
       var student1 = new HashMap<String, Object>() {{
         put("studentFirstName", "Sally");
         put("studentMiddleInitial", "A");
@@ -676,11 +677,11 @@ class SubmissionUtilitiesTest {
         Map.entry("students", List.of(student1, student2))
       )).build();
 
-      assertThat(SubmissionUtilities.canSkipIncomeSections(submission)).isTrue();
+      assertThat(SubmissionUtilities.needsIncomeVerification(submission)).isFalse();
     }
 
     @Test
-    void trueWhenAllStudentsWouldAttendCepSchool() {
+    void falseWhenAllStudentsWouldAttendCepSchool() {
       var student1 = new HashMap<String, Object>() {{
         put("studentFirstName", "Sally");
         put("studentMiddleInitial", "A");
@@ -699,11 +700,11 @@ class SubmissionUtilitiesTest {
         Map.entry("students", List.of(student1, student2))
       )).build();
 
-      assertThat(SubmissionUtilities.canSkipIncomeSections(submission)).isTrue();
+      assertThat(SubmissionUtilities.needsIncomeVerification(submission)).isFalse();
     }
 
     @Test
-    void trueWhenHouseholdMemberReceivesCalfresh() {
+    void falseWhenHouseholdMemberReceivesCalfresh() {
       var student1 = new HashMap<String, Object>() {{
         put("studentFirstName", "Sally");
         put("studentMiddleInitial", "A");
@@ -726,7 +727,19 @@ class SubmissionUtilitiesTest {
         Map.entry("students", List.of(student1, student2))
       )).build();
 
-      assertThat(SubmissionUtilities.canSkipIncomeSections(submission)).isTrue();
+      assertThat(SubmissionUtilities.needsIncomeVerification(submission)).isFalse();
     }
+  }
+
+  @Test
+  void testLaterdocDeadline() {
+    var early = DateTime.parse("2023-07-01").toDate();
+    assertThat(SubmissionUtilities.getLaterdocDeadline(early)).isEqualTo("July 8, 2023");
+
+    var justBefore = DateTime.parse("2023-08-07").toDate();
+    assertThat(SubmissionUtilities.getLaterdocDeadline(justBefore)).isEqualTo("August 14, 2023");
+
+    var justAfter = DateTime.parse("2023-08-10").toDate();
+    assertThat(SubmissionUtilities.getLaterdocDeadline(justAfter)).isEqualTo("August 15, 2023");
   }
 }


### PR DESCRIPTION
* Add "docPendingConfirmation" page to tell the user we need more docs from them.
* Create a utils method `getMissingDocUploads` which does the logic to determine whether any doctypes were needed and are missing.
* Redo the flows-config logic for the doc upload section to take the user to that page whenever they would have otherwise gone to the doc upload confirmation page.
* This necessitated flipping the return value of some of the other Condition's in order to get the `nextScreens` logic to fall back to the right page.

This logic is really complicated now! I wouldn't be surprised if I made a mistake. There is a subsequent story to write a journey test of some doc upload situations.