### PR TITLE
Remove useless demo config and add production config

### DIFF
--- a/src/main/resources/application-demo.yaml
+++ b/src/main/resources/application-demo.yaml
@@ -2,4 +2,5 @@ spring:
   thymeleaf:
     cache: true
 sentry:
+  dsn: ${SENTRY_DSN}
   environment: demo

--- a/src/main/resources/application-production.yaml
+++ b/src/main/resources/application-production.yaml
@@ -2,4 +2,4 @@ spring:
   thymeleaf:
     cache: true
 sentry:
-  environment: demo
+  environment: production

--- a/src/main/resources/application-production.yaml
+++ b/src/main/resources/application-production.yaml
@@ -2,4 +2,5 @@ spring:
   thymeleaf:
     cache: true
 sentry:
+  dsn: ${SENTRY_DSN}
   environment: production

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -93,7 +93,6 @@ server:
     whitelabel:
       enabled: false
 sentry:
-  dsn: ${SENTRY_DSN:-""}
   traces-sample-rate: 0.3
   environment: production
   exception-resolver-order: -2147483647 # send to sentry exceptions handled by @ExceptionHandler's

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -42,5 +42,4 @@ logging:
     root: INFO
     org.apache.commons.beanutils: INFO
 sentry:
-  dsn: ""
   traces-sample-rate: 0


### PR DESCRIPTION
* I don't think the demo config was doing anything since the datasource is clearly wrong (yet demo works). Also, the S3 bucket name is the same as in application.yaml, so why would that be necessary?
* This adds a production YAML, too, since we want to set `thymeleaf.cache` to true there.