### PR TITLE
Update after-submit actions to do nothing the second time

### DIFF
--- a/src/main/java/org/homeschoolpebt/app/data/TransmissionRepositoryService.java
+++ b/src/main/java/org/homeschoolpebt/app/data/TransmissionRepositoryService.java
@@ -3,7 +3,6 @@ package org.homeschoolpebt.app.data;
 import formflow.library.data.Submission;
 import formflow.library.data.SubmissionRepository;
 import jakarta.transaction.Transactional;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
@@ -34,6 +33,10 @@ public class TransmissionRepositoryService {
     this.transmissionRepository.save(transmission);
 
     return transmission;
+  }
+
+  public boolean transmissionExists(Submission submission) {
+    return transmissionRepository.getTransmissionBySubmission(submission) != null;
   }
 
   public Transmission createLaterdocTransmissionRecord(Submission submission) {

--- a/src/main/java/org/homeschoolpebt/app/submission/actions/HandleApplicationSigned.java
+++ b/src/main/java/org/homeschoolpebt/app/submission/actions/HandleApplicationSigned.java
@@ -13,8 +13,6 @@ import org.homeschoolpebt.app.utils.SubmissionUtilities;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-
 @Slf4j
 @Component
 public class HandleApplicationSigned implements Action {
@@ -26,6 +24,11 @@ public class HandleApplicationSigned implements Action {
   private TransmissionRepositoryService transmissionRepositoryService;
 
   public void run(Submission submission) {
+    if (transmissionRepositoryService.transmissionExists(submission)) {
+      // already submitted. don't do anything again.
+      return;
+    }
+
     var transmission = transmissionRepositoryService.createTransmissionRecord(submission);
 
     PebtMessage message;

--- a/src/main/java/org/homeschoolpebt/app/submission/actions/HandleLaterdocSubmitted.java
+++ b/src/main/java/org/homeschoolpebt/app/submission/actions/HandleLaterdocSubmitted.java
@@ -18,6 +18,11 @@ public class HandleLaterdocSubmitted implements Action {
   private TransmissionRepositoryService transmissionRepositoryService;
 
   public void run(Submission submission) {
+    if (transmissionRepositoryService.transmissionExists(submission)) {
+      // already submitted. don't do anything again.
+      return;
+    }
+
     var transmission = transmissionRepositoryService.createLaterdocTransmissionRecord(submission);
 
     // send laterdoc receipt confirmation message

--- a/src/main/resources/templates/pebt/nextSteps.html
+++ b/src/main/resources/templates/pebt/nextSteps.html
@@ -9,7 +9,6 @@
       <div class="notice--warning notice-container spacing-below-25">
         <p th:utext="#{next-steps.warning}"></p>
       </div>
-      <div th:replace="~{fragments/goBack :: goBackLink}"></div>
       <main id="content" role="main" class="form-card spacing-above-35">
         <th:block th:replace="~{'fragments/icons' :: nextSteps}"></th:block>
         <th:block

--- a/src/test/java/org/homeschoolpebt/app/data/TransmissionRepositoryServiceTest.java
+++ b/src/test/java/org/homeschoolpebt/app/data/TransmissionRepositoryServiceTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles("test")
 @SpringBootTest
-class TransmissionReposItoryServiceTest {
+class TransmissionRepositoryServiceTest {
   @Autowired
   private SubmissionRepositoryService submissionRepositoryService;
 

--- a/src/test/java/org/homeschoolpebt/app/submission/actions/HandleApplicationSignedTest.java
+++ b/src/test/java/org/homeschoolpebt/app/submission/actions/HandleApplicationSignedTest.java
@@ -1,0 +1,68 @@
+package org.homeschoolpebt.app.submission.actions;
+
+import formflow.library.data.Submission;
+import formflow.library.email.MailgunEmailClient;
+import org.homeschoolpebt.app.data.Transmission;
+import org.homeschoolpebt.app.data.TransmissionRepositoryService;
+import org.homeschoolpebt.app.submission.messages.TwilioSmsClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class HandleApplicationSignedTest {
+  @InjectMocks
+  HandleApplicationSigned handleApplicationSigned;
+
+  @Mock
+  TransmissionRepositoryService transmissionRepositoryService;
+
+  @Mock
+  MailgunEmailClient mailgunEmailClient;
+
+  @Mock
+  TwilioSmsClient twilioSmsClient;
+
+  @Test
+  void createsATransmission() {
+    Submission submission = Submission.builder().flow("pebt").inputData(Map.ofEntries(
+      Map.entry("firstName", "T. Est"),
+      Map.entry("lastName", "Mc TestUser"),
+      Map.entry("email", "test@example.com"),
+      Map.entry("phoneNumber", "15105551234")
+    )).build();
+
+    Transmission transmission = Transmission.fromSubmission(submission);
+    transmission.setConfirmationNumber("1000100");
+
+    when(transmissionRepositoryService.createTransmissionRecord(submission)).thenReturn(transmission);
+    when(mailgunEmailClient.sendEmail(anyString(), anyString(), anyString())).thenReturn(null);
+    doNothing().when(twilioSmsClient).sendMessage(anyString(), anyString());
+
+    handleApplicationSigned.run(submission);
+
+    verify(transmissionRepositoryService, times(1)).createTransmissionRecord(submission);
+  }
+
+  @Test
+  void doesNothingIfTheTransmissionAlreadyExists() {
+    Submission submission = Submission.builder().flow("pebt").inputData(Map.ofEntries(
+      Map.entry("firstName", "T. Est"),
+      Map.entry("lastName", "Mc TestUser"),
+      Map.entry("email", "test@example.com"),
+      Map.entry("phoneNumber", "15105551234")
+    )).build();
+
+    when(transmissionRepositoryService.transmissionExists(submission)).thenReturn(true);
+
+    handleApplicationSigned.run(submission);
+
+    verify(transmissionRepositoryService, times(0)).createTransmissionRecord(submission);
+  }
+}


### PR DESCRIPTION
If the applicant signs the app, goes back, and resubmits the signature page, we don't want their app to be transmitted twice. (And, they should only receive the first copy of the confirmation message.)

This commit updates the HandleApplicationSigned and HandleLaterdocSubmitted actions to do nothing if the transmission already exists.