### PR TITLE
Remove "I don't have a mailing address" link

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -124,7 +124,6 @@ has-income.title.individual=Do you have a job?
 has-income.title.multiple=Does anyone in the household have a job?
 homeAddress.apartment=Apartment \#
 homeAddress.city=What is the city?
-homeAddress.iDontHaveOne=I don't have a mailing address
 homeAddress.state=What is the state?
 homeAddress.street-address=What is the street address?
 homeAddress.subtitle=If they don't have a permanent address, use a family or friend's address where you can get mail over the next 3 months.

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -124,7 +124,6 @@ has-income.title.individual=Tiene trabajo?
 has-income.title.multiple=¿Alguien en el hogar tiene trabajo?
 homeAddress.apartment=Departamento \#
 homeAddress.city=¿En qué ciudad?
-homeAddress.iDontHaveOne=No tengo direccion de correo
 homeAddress.state=¿En qué estado?
 homeAddress.street-address=¿Cuál es la dirección de la calle?
 homeAddress.subtitle=Si no tienen una dirección permanente, use la dirección de un familiar o amigo donde pueda recibir correo durante los próximos 3 meses.

--- a/src/main/resources/templates/pebt/homeAddress.html
+++ b/src/main/resources/templates/pebt/homeAddress.html
@@ -27,9 +27,6 @@
             </div>
           </th:block>
         </th:block>
-        <p class="spacing-above-35">
-          <a href="#" th:text="#{homeAddress.iDontHaveOne}"></a>
-        </p>
       </main>
     </div>
   </section>


### PR DESCRIPTION
This link was going to go to a flow section that we deprioritized.
