### PR TITLE
Store twilio & mailgun messages in `sent_messages` table

### DIFF
--- a/src/main/java/org/homeschoolpebt/app/data/SentMessage.java
+++ b/src/main/java/org/homeschoolpebt/app/data/SentMessage.java
@@ -1,0 +1,44 @@
+package org.homeschoolpebt.app.data;
+
+import formflow.library.data.Submission;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.util.Date;
+import java.util.UUID;
+
+import static jakarta.persistence.TemporalType.TIMESTAMP;
+
+@Entity
+@Table(name = "sent_messages")
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class SentMessage {
+  @Id
+  @GeneratedValue
+  private UUID id;
+
+  @ManyToOne
+  @JoinColumn(name = "submission_id")
+  private Submission submission;
+
+  @Column(name = "message_name")
+  private String messageName;
+
+  @CreationTimestamp
+  @Temporal(TIMESTAMP)
+  @Column(name = "sent_at")
+  private Date sentAt;
+
+  @Column(name = "sent_status")
+  private String sentStatus;
+
+  @Column(name = "provider")
+  private String provider;
+
+  @Column(name = "provider_message_id")
+  private String providerMessageId;
+}

--- a/src/main/java/org/homeschoolpebt/app/data/SentMessageRepository.java
+++ b/src/main/java/org/homeschoolpebt/app/data/SentMessageRepository.java
@@ -1,0 +1,10 @@
+package org.homeschoolpebt.app.data;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface SentMessageRepository extends JpaRepository<SentMessage, UUID> {
+}

--- a/src/main/java/org/homeschoolpebt/app/data/SentMessageRepositoryService.java
+++ b/src/main/java/org/homeschoolpebt/app/data/SentMessageRepositoryService.java
@@ -1,0 +1,16 @@
+package org.homeschoolpebt.app.data;
+
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+public class SentMessageRepositoryService {
+  @Autowired
+  SentMessageRepository sentMessageRepository;
+
+  public SentMessage save(SentMessage sentMessage) {
+    return sentMessageRepository.save(sentMessage);
+  }
+}

--- a/src/main/java/org/homeschoolpebt/app/submission/messages/ScheduledMessages.java
+++ b/src/main/java/org/homeschoolpebt/app/submission/messages/ScheduledMessages.java
@@ -3,6 +3,8 @@ package org.homeschoolpebt.app.submission.messages;
 import formflow.library.data.Submission;
 import formflow.library.email.MailgunEmailClient;
 import lombok.extern.slf4j.Slf4j;
+import org.homeschoolpebt.app.data.SentMessage;
+import org.homeschoolpebt.app.data.SentMessageRepositoryService;
 import org.homeschoolpebt.app.data.Transmission;
 import org.homeschoolpebt.app.data.TransmissionRepository;
 import org.homeschoolpebt.app.utils.SubmissionUtilities;
@@ -12,6 +14,7 @@ import org.springframework.shell.standard.ShellMethod;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAdjuster;
+import java.util.Date;
 import java.util.List;
 
 import static java.time.temporal.ChronoUnit.DAYS;
@@ -22,14 +25,16 @@ public class ScheduledMessages {
   private final MailgunEmailClient mailgunEmailClient;
   private final TwilioSmsClient twilioSmsClient;
   private final TransmissionRepository transmissionRepository;
+  private final SentMessageRepositoryService sentMessageRepositoryService;
   static final List<TemporalAdjuster> REMINDER_TIME_FRAMES = List.of(
     t -> t.minus(2, DAYS),
     t -> t.minus(4, DAYS));
 
-  public ScheduledMessages(MailgunEmailClient mailgunEmailClient, TwilioSmsClient twilioSmsClient, TransmissionRepository transmissionRepository) {
+  public ScheduledMessages(MailgunEmailClient mailgunEmailClient, TwilioSmsClient twilioSmsClient, TransmissionRepository transmissionRepository, SentMessageRepositoryService sentMessageRepositoryService) {
     this.mailgunEmailClient = mailgunEmailClient;
     this.twilioSmsClient = twilioSmsClient;
     this.transmissionRepository = transmissionRepository;
+    this.sentMessageRepositoryService = sentMessageRepositoryService;
   }
 
   @ShellMethod(key = "checkForUnsubmittedDocs")
@@ -57,7 +62,16 @@ public class ScheduledMessages {
     if (!emailAddress.isBlank()) {
       var emailMessage = message.renderEmail();
       log.info("Sending email %s for submission %s".formatted(message.getClass().getSimpleName(), submission.getId()));
-      mailgunEmailClient.sendEmail(emailMessage.getSubject(), emailAddress, emailMessage.getBodyHtml());
+      var mailgunResponse = mailgunEmailClient.sendEmail(emailMessage.getSubject(), emailAddress, emailMessage.getBodyHtml());
+      sentMessageRepositoryService.save(
+        SentMessage.builder()
+          .submission(submission)
+          .messageName(message.getClass().getSimpleName())
+          .sentAt(new Date())
+          .provider("mailgun")
+          .providerMessageId(mailgunResponse.getId())
+          .build()
+      );
     } else {
       log.info("Not sending email %s: no email address for submission %s".formatted(message.getClass().getSimpleName(), submission.getId()));
     }
@@ -66,7 +80,16 @@ public class ScheduledMessages {
     if (!phoneNumber.isBlank()) {
       var smsMessage = message.renderSms();
       log.info("Sending SMS %s for submission %s".formatted(message.getClass().getSimpleName(), submission.getId()));
-      twilioSmsClient.sendMessage(phoneNumber, smsMessage.getBody());
+      var twilioResponse = twilioSmsClient.sendMessage(phoneNumber, smsMessage.getBody());
+      sentMessageRepositoryService.save(
+        SentMessage.builder()
+          .submission(submission)
+          .messageName(message.getClass().getSimpleName())
+          .sentAt(new Date())
+          .provider("twilio")
+          .providerMessageId(twilioResponse.getSid())
+          .build()
+      );
     } else {
       log.info("Not sending SMS %s: no phone number for submission %s".formatted(message.getClass().getSimpleName(), submission.getId()));
     }

--- a/src/main/java/org/homeschoolpebt/app/submission/messages/TwilioSmsClient.java
+++ b/src/main/java/org/homeschoolpebt/app/submission/messages/TwilioSmsClient.java
@@ -17,9 +17,10 @@ public class TwilioSmsClient {
   @Value("${twilio.messaging.service.sid}")
   private String twilioMessagingServiceSid;
 
-  public void sendMessage(String to, String body) {
+  public Message sendMessage(String to, String body) {
     Twilio.init(twilioAccountSid, twilioAuthToken);
     Message twilioMessage = Message.creator(new PhoneNumber(to), twilioMessagingServiceSid, body).create();
-    log.info("Twilio message request sent; SID=%s; Status=%s".formatted(twilioMessage.getAccountSid(), twilioMessage.getStatus()));
+    log.info("Twilio message request sent; SID=%s; Status=%s".formatted(twilioMessage.getSid(), twilioMessage.getStatus()));
+    return twilioMessage;
   }
 }

--- a/src/main/resources/db/migration/V2023.06.27.15.00.55__Create_sent_messages.sql
+++ b/src/main/resources/db/migration/V2023.06.27.15.00.55__Create_sent_messages.sql
@@ -1,0 +1,9 @@
+CREATE TABLE sent_messages (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  submission_id UUID NOT NULL,
+  message_name VARCHAR NOT NULL,
+  sent_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+  sent_status VARCHAR,
+  provider VARCHAR,
+  provider_message_id VARCHAR
+)

--- a/src/test/java/org/homeschoolpebt/app/journeys/PebtFlowJourneyTest.java
+++ b/src/test/java/org/homeschoolpebt/app/journeys/PebtFlowJourneyTest.java
@@ -1,5 +1,7 @@
 package org.homeschoolpebt.app.journeys;
 
+import com.mailgun.model.message.MessageResponse;
+import com.twilio.rest.api.v2010.account.Message;
 import formflow.library.email.MailgunEmailClient;
 import org.homeschoolpebt.app.submission.messages.TwilioSmsClient;
 import org.homeschoolpebt.app.utils.AbstractBasePageTest;
@@ -16,10 +18,10 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.homeschoolpebt.app.utils.YesNoAnswer.NO;
 import static org.homeschoolpebt.app.utils.YesNoAnswer.YES;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 public class PebtFlowJourneyTest extends AbstractBasePageTest {
   @MockBean
@@ -29,6 +31,10 @@ public class PebtFlowJourneyTest extends AbstractBasePageTest {
 
   @Test
   void fullUbiFlow() {
+    var mockMessageResponse = MessageResponse.builder().id("id").message("message").build();
+    when(mailgunEmailClient.sendEmail(any(), any(), any())).thenReturn(mockMessageResponse);
+    when(twilioSmsClient.sendMessage(any(), any())).thenReturn(mock(Message.class));
+
     // Landing screen
     assertPageTitle("Get food money for students.");
     testPage.clickButton("Apply now");

--- a/src/test/java/org/homeschoolpebt/app/submission/actions/HandleApplicationSignedTest.java
+++ b/src/test/java/org/homeschoolpebt/app/submission/actions/HandleApplicationSignedTest.java
@@ -1,7 +1,10 @@
 package org.homeschoolpebt.app.submission.actions;
 
+import com.mailgun.model.message.MessageResponse;
+import com.twilio.rest.api.v2010.account.Message;
 import formflow.library.data.Submission;
 import formflow.library.email.MailgunEmailClient;
+import org.homeschoolpebt.app.data.SentMessageRepositoryService;
 import org.homeschoolpebt.app.data.Transmission;
 import org.homeschoolpebt.app.data.TransmissionRepositoryService;
 import org.homeschoolpebt.app.submission.messages.TwilioSmsClient;
@@ -24,6 +27,9 @@ class HandleApplicationSignedTest {
   TransmissionRepositoryService transmissionRepositoryService;
 
   @Mock
+  SentMessageRepositoryService sentMessageRepositoryService;
+
+  @Mock
   MailgunEmailClient mailgunEmailClient;
 
   @Mock
@@ -41,9 +47,10 @@ class HandleApplicationSignedTest {
     Transmission transmission = Transmission.fromSubmission(submission);
     transmission.setConfirmationNumber("1000100");
 
+    var mockMessageResponse = MessageResponse.builder().id("id").message("message").build();
     when(transmissionRepositoryService.createTransmissionRecord(submission)).thenReturn(transmission);
-    when(mailgunEmailClient.sendEmail(anyString(), anyString(), anyString())).thenReturn(null);
-    doNothing().when(twilioSmsClient).sendMessage(anyString(), anyString());
+    when(mailgunEmailClient.sendEmail(any(), any(), any())).thenReturn(mockMessageResponse);
+    when(twilioSmsClient.sendMessage(any(), any())).thenReturn(mock(Message.class));
 
     handleApplicationSigned.run(submission);
 

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -2,7 +2,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <!-- encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -%kvp- %msg%n</pattern>
+      <pattern>%boldCyan(%d{HH:mm:ss.SSS}) [%thread] %highlight(%-5level) %boldMagenta(%logger{36}) - %msg%n</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
This creates a simple table that stores IDs for all the twilio and
mailgun messages, in case we need to go back and check them for some
reason.
