### PR TITLE
Fix JS glitch preventing inputting affidavit number

### DIFF
--- a/src/main/resources/templates/pebt/studentsSchoolYear.html
+++ b/src/main/resources/templates/pebt/studentsSchoolYear.html
@@ -50,14 +50,14 @@
                           th:replace="~{'fragments/inputs/radio' :: radio(inputName='studentSchoolType',value='homeschool', label=#{students-add.homeschool}, followUpId='#follow-up-affidavit-number')}"/>
                       </th:block>
                     </th:block>
+                  </div>
 
-                    <div class="question-with-follow-up__follow-up" id="follow-up-affidavit-number">
-                      <th:block th:replace="~{'fragments/inputs/text' :: text(
-                        inputName='studentHomeschoolAffidavitNumber',
-                        label=#{students-school-year.homeschool-affidavit-label},
-                        helpText=#{students-school-year.homeschool-affidavit-help-text})}
-                      "/>
-                    </div>
+                  <div class="question-with-follow-up__follow-up" id="follow-up-affidavit-number">
+                    <th:block th:replace="~{'fragments/inputs/text' :: text(
+                      inputName='studentHomeschoolAffidavitNumber',
+                      label=#{students-school-year.homeschool-affidavit-label},
+                      helpText=#{students-school-year.homeschool-affidavit-help-text})}
+                    "/>
                   </div>
 
                   <div class="question-with-follow-up__follow-up" id="follow-up-virtual-school-name">
@@ -67,6 +67,7 @@
                       "/>
                   </div>
                 </div>
+
                 <div class="form-card__footer">
                   <th:block th:replace="~{fragments/inputs/submitButton :: submitButton(text=#{general.inputs.continue})}"/>
                 </div>


### PR DESCRIPTION
Just a boring JS issue since we were accidentally putting the `<input>`s
for the follow-up items within the `question-with-follow-up__question`.

That means that whenever the user clicked on an `<input>` within the
follow-ups, it was triggering it to close and reopen, which defocused
the field.
