### PR TITLE
Add getSelectableStudents to SubmissionUtilities

### DIFF
--- a/src/main/java/org/homeschoolpebt/app/utils/SubmissionUtilities.java
+++ b/src/main/java/org/homeschoolpebt/app/utils/SubmissionUtilities.java
@@ -12,7 +12,6 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 
 public class SubmissionUtilities {
-
   public static DecimalFormat decimalFormat = new DecimalFormat("#,###.00");
   public static DecimalFormat decimalFormatWithoutComma = new DecimalFormat("#.00");
   public static final String APPLICANT = "applicant";
@@ -507,5 +506,19 @@ public class SubmissionUtilities {
   public static boolean applicantIsInHousehold(Submission submission) {
     return submission.getInputData().getOrDefault("applicantIsInHousehold", "false").equals("true");
   }
-}
 
+  public static Map<String, String> getSelectableStudents(Submission submission, String thatsYou) {
+    var result = new LinkedHashMap<String, String>();
+    if (applicantIsInHousehold(submission) && isApplyingForSelf(submission)) {
+      var fullName = applicantFullName(submission);
+      var labeledName = fullName + " " + thatsYou;
+      result.put(labeledName, fullName);
+    }
+    var students = (Collection<HashMap<String, String>>) submission.getInputData().getOrDefault("students", List.of());
+    for(var student: students) {
+      var fullName = studentFullName(student);
+      result.put(fullName, fullName);
+    }
+    return result;
+  }
+}

--- a/src/main/resources/templates/pebt/householdList.html
+++ b/src/main/resources/templates/pebt/householdList.html
@@ -16,19 +16,10 @@
           <div class="boxed-content text--centered">
             <strong th:text="#{household-list.your-household}"></strong>
             <ul class="subflow-list list--bulleted">
-              <th:block th:if="${T(org.homeschoolpebt.app.utils.SubmissionUtilities).applicantIsInHousehold(submission) && !T(org.homeschoolpebt.app.utils.SubmissionUtilities).isApplyingForSelf(submission)}">
-                <li class="spacing-below-15" th:text="${inputData.firstName} + ' ' + ${inputData.lastName} + ' (' + #{household-list.thats-you} + ')'"></li>
-              </th:block>
-              <th:block th:if="${inputData.containsKey('students')}">
-                <li th:each="student, iter: ${inputData.students}" class="spacing-below-15">
-                  <span class="space-between">
-                    <span>
-                      <span th:text="${student.studentFirstName}"></span>
-                      <span th:text="${student.studentMiddleInitial}" th:if="${!#strings.isEmpty(student.studentMiddleInitial)}"></span>
-                      <span th:text="${student.studentLastName}"></span>
-                    </span>
-                  </span>
-                </li>
+              <th:block th:with="householdMembers=${T(org.homeschoolpebt.app.utils.SubmissionUtilities).getSelectableStudents(submission, #messages.msg('household-list.thats-you'))}">
+                <th:block th:each="householdMember, iter: ${householdMembers.entrySet()}">
+                  <li class="spacing-below-15" th:text="${householdMember.getKey()}"></li>
+                </th:block>
               </th:block>
               <th:block th:if="${inputData.containsKey('household')}">
                 <li th:each="householdMember, iter: ${inputData.household}" class="spacing-below-15">


### PR DESCRIPTION
This adds a method that I hope we can call in all the places we show "(that's you!)"

It returns a map because we can then use the keys as the form `label` and the values as the form `values`.

@sree-cfa If you like it, I can look into using it in "Don't show duplicate names during document uploader". I also need to manually test it still! I am sharing this now to get early feedback.