### PR TITLE
Skip only *earned* income when there are no jobs

### DIFF
--- a/src/main/java/org/homeschoolpebt/app/submission/conditions/IsRequiredToVerifyIncome.java
+++ b/src/main/java/org/homeschoolpebt/app/submission/conditions/IsRequiredToVerifyIncome.java
@@ -1,14 +1,12 @@
 package org.homeschoolpebt.app.submission.conditions;
 
-import formflow.library.config.submission.Condition;
 import formflow.library.data.Submission;
 import org.homeschoolpebt.app.utils.SubmissionUtilities;
 import org.springframework.stereotype.Component;
 
 @Component
-public class NeedsIncomeVerification implements Condition {
-  @Override
+public class IsRequiredToVerifyIncome extends AbstractPebtCondition {
   public Boolean run(Submission submission) {
-    return SubmissionUtilities.needsIncomeVerification(submission);
+    return SubmissionUtilities.isRequiredToVerifyIncome(submission);
   }
 }

--- a/src/main/java/org/homeschoolpebt/app/submission/conditions/NeedsEarnedIncomeDocs.java
+++ b/src/main/java/org/homeschoolpebt/app/submission/conditions/NeedsEarnedIncomeDocs.java
@@ -1,0 +1,14 @@
+package org.homeschoolpebt.app.submission.conditions;
+
+import formflow.library.config.submission.Condition;
+import formflow.library.data.Submission;
+import org.homeschoolpebt.app.utils.SubmissionUtilities;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NeedsEarnedIncomeDocs implements Condition {
+  @Override
+  public Boolean run(Submission submission) {
+    return SubmissionUtilities.needsEarnedIncomeDocuments(submission);
+  }
+}

--- a/src/main/java/org/homeschoolpebt/app/utils/SubmissionUtilities.java
+++ b/src/main/java/org/homeschoolpebt/app/utils/SubmissionUtilities.java
@@ -422,7 +422,9 @@ public class SubmissionUtilities {
       .allMatch(schoolName -> StudentsPreparer.OFFICAL_SCHOOL_FORMAT.matcher(schoolName).matches());
   }
 
-  public static boolean needsIncomeVerification(Submission submission) {
+  // Whether the applicant must verify income
+  // (i.e. they are not exempt for some reason - CEP, etc.)
+  public static boolean isRequiredToVerifyIncome(Submission submission) {
     var students = (List<Map<String, Object>>) submission.getInputData().getOrDefault("students", new ArrayList<HashMap<String, Object>>());
 
     // All students have designation (foster/runaway/etc.)?
@@ -446,13 +448,26 @@ public class SubmissionUtilities {
     }
 
     // Any household member receiving benefits?
-    var receivingBenefits = submission.getInputData().getOrDefault("householdMemberReceivesBenefits", "none");
+    var receivingBenefits = submission.getInputData().getOrDefault("householdMemberReceivesBenefits", "None of the Above");
     if (!receivingBenefits.equals("None of the Above")) {
       return false;
     }
 
     return true;
   }
+
+  // Whether the applicant needs to upload earned income documents
+  // (i.e. they are required to verify AND they have a job)
+  public static boolean needsEarnedIncomeDocuments(Submission submission) {
+    if (!isRequiredToVerifyIncome(submission)) {
+      return false;
+    }
+
+    // No exception qualifies. Income verification is necessary if there is any earned income.
+    var jobs = (List<HashMap<String, Object>>) submission.getInputData().getOrDefault("income", new ArrayList<HashMap<String, Object>>());
+    return jobs.size() > 0;
+  }
+
   static final DateTime LAST_DAY_OF_APPLICATIONS = new DateTime(2023, 8, 15, 17, 00); // 5pm on Aug 15
   public static String getLaterdocDeadline(Date now) {
     var oneWeekHence = new DateTime(now).plus(Duration.standardDays(7));
@@ -481,12 +496,16 @@ public class SubmissionUtilities {
       missing.add("enrollment");
     }
 
-    var neededIncome = needsIncomeVerification(submission);
+    var neededIncome = needsEarnedIncomeDocuments(submission);
     var skippedIncome = submission.getInputData().getOrDefault("incomeFiles", "[]").equals("[]");
+    if (neededIncome && skippedIncome) {
+      missing.add("income");
+    }
+
     var neededUnearned = getDocUploadUnearnedIncomeList(submission).size() > 0;
     var skippedUnearned = submission.getInputData().getOrDefault("unearnedIncomeFiles", "[]").equals("[]");
-    if ((neededIncome && skippedIncome) || (neededUnearned && skippedUnearned)) {
-      missing.add("income");
+    if (neededUnearned && skippedUnearned) {
+      missing.add("unearned-income");
     }
 
     return missing;

--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -118,7 +118,7 @@ flow:
       - name: signpostHouseholdDetails
         condition: HasHousehold
       - name: signpostIncome
-        condition: NeedsIncomeVerification
+        condition: IsRequiredToVerifyIncome
       - name: addingDocuments
   signpostHouseholdDetails:
     nextScreens:
@@ -133,7 +133,7 @@ flow:
   householdReceivesBenefits:
     nextScreens:
       - name: signpostIncome
-        condition: NeedsIncomeVerification
+        condition: IsRequiredToVerifyIncome
       - name: addingDocuments
     onPostAction: ClearOtherCaseNumberFields
     crossFieldValidationAction: FDPIRCaseNumberValidationAction
@@ -148,7 +148,7 @@ flow:
     nextScreens:
       - name: incomeAddJob
         condition: HasIncome
-      - name: addingDocuments
+      - name: incomeUnearnedRetirementTypes
   incomeAddJob:
     nextScreens:
       - name: incomeChooseHouseholdMember
@@ -246,14 +246,18 @@ flow:
       - name: uploadEnrollmentDocuments
         condition: NeedsEnrollmentDocs
       - name: uploadIncomeDocuments
-        condition: NeedsIncomeVerification
+        condition: NeedsEarnedIncomeDocs
+      - name: uploadUnearnedIncomeDocuments
+        condition: NeedsUnearnedIncomeDocs
       - name: docPendingConfirmation
         condition: MissingAnyDocumentUploads
       - name: docSubmitConfirmation
   uploadEnrollmentDocuments:
     nextScreens:
       - name: uploadIncomeDocuments
-        condition: NeedsIncomeVerification
+        condition: NeedsEarnedIncomeDocs
+      - name: uploadUnearnedIncomeDocuments
+        condition: NeedsUnearnedIncomeDocs
       - name: docPendingConfirmation
         condition: MissingAnyDocumentUploads
       - name: docSubmitConfirmation

--- a/src/main/resources/templates/pebt/addingDocuments.html
+++ b/src/main/resources/templates/pebt/addingDocuments.html
@@ -19,7 +19,7 @@
           <ol class="list--numbered">
             <li th:text="#{adding-documents.students-identity}"></li>
             <li th:text="#{adding-documents.students-enrollment}" th:if="${T(org.homeschoolpebt.app.utils.SubmissionUtilities).needsEnrollmentDocs(submission)}"></li>
-            <li th:text="#{adding-documents.income-proof}" th:if="${T(org.homeschoolpebt.app.utils.SubmissionUtilities).needsIncomeVerification(submission)}"></li>
+            <li th:text="#{adding-documents.income-proof}" th:if="${T(org.homeschoolpebt.app.utils.SubmissionUtilities).isRequiredToVerifyIncome(submission)}"></li>
           </ol>
         </div>
 

--- a/src/main/resources/templates/pebt/docPendingConfirmation.html
+++ b/src/main/resources/templates/pebt/docPendingConfirmation.html
@@ -21,7 +21,7 @@
             <ul class="list--bulleted">
               <li th:if="${#arrays.contains(missingDocs, 'identity')}" th:text="#{adding-documents.students-identity}"></li>
               <li th:if="${#arrays.contains(missingDocs, 'enrollment')}" th:text="#{adding-documents.students-enrollment}"></li>
-              <li th:if="${#arrays.contains(missingDocs, 'income')}" th:text="#{adding-documents.income-proof}"></li>
+              <li th:if="${#arrays.contains(missingDocs, 'income') or #arrays.contains(missingDocs, 'unearned-income')}" th:text="#{adding-documents.income-proof}"></li>
             </ul>
           </th:block>
 

--- a/src/test/java/org/homeschoolpebt/app/journeys/ApplyForSelfJourneyTest.java
+++ b/src/test/java/org/homeschoolpebt/app/journeys/ApplyForSelfJourneyTest.java
@@ -31,7 +31,7 @@ public class ApplyForSelfJourneyTest extends AbstractBasePageTest {
   TwilioSmsClient twilioSmsClient;
 
   @Test
-  void fullUbiFlow() {
+  void selfApplyFullFlow() {
     var mockMessageResponse = MessageResponse.builder().id("id").message("message").build();
     when(mailgunEmailClient.sendEmail(any(), any(), any())).thenReturn(mockMessageResponse);
     when(twilioSmsClient.sendMessage(any(), any())).thenReturn(mock(Message.class));
@@ -180,35 +180,8 @@ public class ApplyForSelfJourneyTest extends AbstractBasePageTest {
     // Income
     testPage.clickButton("Get started"); // Income signpost
     assertPageTitle("Do you have a job?");
-    testPage.clickButton(YES.getDisplayValue());
-    assertPageTitle("Great! Let's add all your jobs.");
-    testPage.clickButton("Add a job");
-    assertPageTitle("Who do you want to add the job for?");
-    testPage.findElementByCssSelector("input[type=radio]").click(); // Click first radio button
-    testPage.clickContinue();
-    assertPageTitle("Add your job");
-    testPage.enter("incomeJobName", "Hobby Jobby"); // Name of job
-    testPage.clickButton("Continue");
-    // TODO: Add a case for self-employed income as well.
-    testPage.clickButton(NO.getDisplayValue()); // Was self-employed?
-    testPage.clickButton(YES.getDisplayValue()); // Is this job paid by the hour?
-    testPage.enter("incomeHourlyWage", "10"); // What's [x]'s hourly wage?
-    testPage.enter("incomeHoursPerWeek", "40");
-    testPage.clickContinue();
-    assertPageTitle("Do you think you will make less from this job in future months?");
-    testPage.goBack();
-    testPage.goBack();
-    testPage.clickButton(NO.getDisplayValue()); // Is this job paid by the hour?
-    testPage.findElementById("incomeRegularPayInterval-semimonthly-label").click(); // How does [x] get paid?
-    testPage.enterByCssSelector("#follow-up-semimonthly input[name='incomeRegularPayAmount']", "1000");
-    testPage.clickContinue();
-    testPage.findElementById("incomeWillBeLess-true-label").click(); // Will income be less?
-    testPage.enter("incomeCustomMonthlyIncome", "500");
-    testPage.enter("incomeWillBeLessDescription", "Some string about why income will be less.");
-    testPage.clickContinue();
-    assertPageTitle("Great! Any other jobs in the household to add?");
-    testPage.clickButton("I'm done adding jobs");
-    testPage.clickLink("Keep going"); // Almost done with income!
+    testPage.clickButton(NO.getDisplayValue());
+    // Skips earned income
     testPage.findElementById("incomeUnearnedRetirementTypes-incomeSocialSecurity").click(); // Does anyone get retirement income?
     testPage.clickButton("Submit");
     testPage.findElementById("incomeUnearnedTypes-incomeChildSupport").click(); // Does anyone get unearned income i.e. benefits income?
@@ -221,6 +194,9 @@ public class ApplyForSelfJourneyTest extends AbstractBasePageTest {
 
     // Document Uploader
     assertPageTitle("Adding Documents");
+    assertThat(testPage.getCssSelectorText(".boxed-content")).contains("Students' proof of identity");
+    assertThat(testPage.getCssSelectorText(".boxed-content")).contains("Proof of virtual school enrollment");
+    assertThat(testPage.getCssSelectorText(".boxed-content")).contains("Proof of income");
     testPage.clickButton("Get started");
     testPage.clickButton("Got it"); // How to add files from your device
     assertPageTitle("Add proof of identity");
@@ -232,10 +208,6 @@ public class ApplyForSelfJourneyTest extends AbstractBasePageTest {
     // https://app.asana.com/0/1204253048942731/1204911485797535
     assertPageTitle("Add proof of virtual school enrollment");
     testPage.clickLink("Skip");
-    assertPageTitle("Add proof of income from the last 30 days");
-    assertThat(testPage.getCssSelectorText(".boxed-content")).contains("Testy McTesterson (that's you!)");
-    uploadJpgFile("incomeFiles");
-    testPage.clickContinue();
     assertPageTitle("Add proof for other income sources");
     assertThat(testPage.getCssSelectorText(".boxed-content")).contains("Social Security");
     uploadJpgFile("unearnedIncomeFiles");

--- a/src/test/java/org/homeschoolpebt/app/utils/SubmissionUtilitiesTest.java
+++ b/src/test/java/org/homeschoolpebt/app/utils/SubmissionUtilitiesTest.java
@@ -646,15 +646,40 @@ class SubmissionUtilitiesTest {
         put("studentDesignations[]", List.of("none"));
         put("studentWouldAttendSchoolName", "01100170124172 - Yu Ming Charter (Alameda County Office of Education)"); // not a CEP school
       }};
+      var job = new HashMap<String, Object>() {{
+        put("incomeJobName", "Hubby Lubby");
+        put("incomeMember", "Rodger Rocklobster");
+      }};
 
       var submission = Submission.builder().inputData(Map.ofEntries(
         Map.entry("firstName", "Johnny"),
         Map.entry("lastName", "Appleseed"),
         Map.entry("householdMemberReceivesBenefits", "None of the Above"),
-        Map.entry("students", List.of(student1, student2))
+        Map.entry("students", List.of(student1, student2)),
+        Map.entry("income", List.of(job))
       )).build();
 
-      assertThat(SubmissionUtilities.needsIncomeVerification(submission)).isTrue();
+      assertThat(SubmissionUtilities.needsEarnedIncomeDocuments(submission)).isTrue();
+    }
+
+    @Test
+    void falseWhenHasIncomeIsFalse() {
+      var student1 = new HashMap<String, Object>() {{
+        put("studentFirstName", "Sally");
+        put("studentMiddleInitial", "A");
+        put("studentLastName", "Starfish");
+        put("studentDesignations[]", List.of("none"));
+        put("studentWouldAttendSchoolName", "Custom School Name");
+      }};
+
+      var submission = Submission.builder().inputData(Map.ofEntries(
+        Map.entry("firstName", "Johnny"),
+        Map.entry("lastName", "Appleseed"),
+        Map.entry("hasIncome", "false"),
+        Map.entry("students", List.of(student1))
+      )).build();
+
+      assertThat(SubmissionUtilities.needsEarnedIncomeDocuments(submission)).isFalse();
     }
 
     @Test
@@ -677,7 +702,7 @@ class SubmissionUtilitiesTest {
         Map.entry("students", List.of(student1, student2))
       )).build();
 
-      assertThat(SubmissionUtilities.needsIncomeVerification(submission)).isFalse();
+      assertThat(SubmissionUtilities.needsEarnedIncomeDocuments(submission)).isFalse();
     }
 
     @Test
@@ -700,7 +725,7 @@ class SubmissionUtilitiesTest {
         Map.entry("students", List.of(student1, student2))
       )).build();
 
-      assertThat(SubmissionUtilities.needsIncomeVerification(submission)).isFalse();
+      assertThat(SubmissionUtilities.needsEarnedIncomeDocuments(submission)).isFalse();
     }
 
     @Test
@@ -727,7 +752,7 @@ class SubmissionUtilitiesTest {
         Map.entry("students", List.of(student1, student2))
       )).build();
 
-      assertThat(SubmissionUtilities.needsIncomeVerification(submission)).isFalse();
+      assertThat(SubmissionUtilities.needsEarnedIncomeDocuments(submission)).isFalse();
     }
   }
 


### PR DESCRIPTION
This commit refactors the previous `needsIncomeVerification` method into
two different methods:
* `isRequiredToVerifyIncome` - this handles the logic to determine
  whether *ALL* income verification can be skipped, and
* `needsEarnedIncomeDocuments` - this handles the logic to determine
  whether the earned income doc upload section should be skipped, which
  is false when the applicant is not required to verify income OR when
  there are no jobs reported on the application.

A couple related changes:
* I updated the ApplyForSelfJourneyTest to test this condition.
* The names of the Conditions have been updated to match these methods.

More description in ASANA-1204918907154109.
