### PR TITLE
Fix Duplicate name in income list

### DIFF
--- a/src/main/java/org/homeschoolpebt/app/utils/SubmissionUtilities.java
+++ b/src/main/java/org/homeschoolpebt/app/utils/SubmissionUtilities.java
@@ -1,17 +1,24 @@
 package org.homeschoolpebt.app.utils;
 
 import formflow.library.data.Submission;
+import java.text.DecimalFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import org.homeschoolpebt.app.preparers.StudentsPreparer;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
-import java.text.DecimalFormat;
-import java.text.SimpleDateFormat;
-import java.util.*;
-
 public class SubmissionUtilities {
+
   public static DecimalFormat decimalFormat = new DecimalFormat("#,###.00");
   public static DecimalFormat decimalFormatWithoutComma = new DecimalFormat("#.00");
   public static final String APPLICANT = "applicant";
@@ -516,6 +523,16 @@ public class SubmissionUtilities {
     var students = (Collection<HashMap<String, String>>) submission.getInputData().getOrDefault("students", List.of());
     for(var student: students) {
       var fullName = studentFullName(student);
+      result.put(fullName, fullName);
+    }
+    return result;
+  }
+
+  public static Map<String, String> getSelectableStudentsAndHousehold(Submission submission, String thatsYou) {
+    var result = getSelectableStudents(submission, thatsYou);
+    var household = (Collection<Map<String, String>>) submission.getInputData().getOrDefault("household", List.of());
+    for (var member : household) {
+      var fullName = householdMemberFullName(member);
       result.put(fullName, fullName);
     }
     return result;

--- a/src/main/resources/templates/pebt/incomeChooseHouseholdMember.html
+++ b/src/main/resources/templates/pebt/incomeChooseHouseholdMember.html
@@ -20,23 +20,10 @@
                     ariaLabel='header',
                     content=~{::householdMembers})}">
                   <th:block th:ref="householdMembers">
-                    <th:block th:with="fullName=${T(org.homeschoolpebt.app.utils.SubmissionUtilities).applicantFullName(submission)}">
-                      <th:block
-                          th:replace="~{'fragments/inputs/radio' :: radio(inputName='incomeMember', value=${fullName}, label=${fullName + ' (' + #messages.msg('household-list.thats-you') + ')'})}"/>
-                    </th:block>
-                    <th:block th:if="${inputData.containsKey('students')}">
-                      <th:block th:each="student, iter: ${inputData.students}">
-                        <th:block th:with="fullName=${T(org.homeschoolpebt.app.utils.SubmissionUtilities).studentFullName(student)}">
-                          <th:block th:replace="~{'fragments/inputs/radio' :: radio(inputName='incomeMember', value=${fullName}, label=${fullName})}"/>
-                        </th:block>
+                    <th:block th:with="household=${T(org.homeschoolpebt.app.utils.SubmissionUtilities).getSelectableStudentsAndHousehold(submission, #messages.msg('household-list.thats-you'))}">
+                      <th:block th:each="member, iter: ${household.entrySet()}">
+                        <th:block th:replace="~{'fragments/inputs/radio' :: radio(inputName='incomeMember', value=${member.getValue()}, label=${member.getKey()})}"/>
                       </th:block>
-                    </th:block>
-                    <th:block th:if="${inputData.containsKey('household')}">
-                      <th:block th:each="hm, iter: ${inputData.household}"
-                                th:with="fullName=${T(org.homeschoolpebt.app.utils.SubmissionUtilities).householdMemberFullName(hm)}">
-                        <th:block th:replace="~{'fragments/inputs/radio' :: radio(inputName='incomeMember', value=${fullName}, label=${fullName})}"/>
-                      </th:block>
-                    </th:block>
                   </th:block>
                 </th:block>
               </th:block>

--- a/src/test/java/org/homeschoolpebt/app/journeys/ApplyForSelfJourneyTest.java
+++ b/src/test/java/org/homeschoolpebt/app/journeys/ApplyForSelfJourneyTest.java
@@ -69,13 +69,13 @@ public class ApplyForSelfJourneyTest extends AbstractBasePageTest {
     // Students subflow
     testPage.clickButton("Get started"); // "Student information" signpost
     assertPageTitle("Add a student");
-    testPage.enter("studentFirstName", "Testy");
-    testPage.enter("studentLastName", "McTesterson");
+    testPage.enter("studentFirstName", "Stud");
+    testPage.enter("studentLastName", "McStudenty");
     testPage.enter("studentBirthdayDay", "1");
     testPage.enter("studentBirthdayMonth", "2");
     testPage.enter("studentBirthdayYear", "1991");
     testPage.clickButton("Add student");
-    assertPageTitle("Do any of the following apply to Testy?");
+    assertPageTitle("Do any of the following apply to Stud?");
     testPage.findElementById("none__checkbox").click();
     testPage.clickContinue();
     assertPageTitle("Tell us about");
@@ -95,8 +95,8 @@ public class ApplyForSelfJourneyTest extends AbstractBasePageTest {
     testPage.clickContinue();
 
     // Personal info
-    testPage.enter("firstName", "Testy");
-    testPage.enter("lastName", "McTesterson");
+    testPage.enter("firstName", "Stud");
+    testPage.enter("lastName", "McStudenty");
     testPage.clickContinue();
 
     // Home address
@@ -200,7 +200,7 @@ public class ApplyForSelfJourneyTest extends AbstractBasePageTest {
     testPage.clickButton("Get started");
     testPage.clickButton("Got it"); // How to add files from your device
     assertPageTitle("Add proof of identity");
-    assertThat(testPage.getCssSelectorText(".boxed-content")).contains("Testy McTesterson");
+    assertThat(testPage.getCssSelectorText(".boxed-content")).contains("Stud McStudenty");
     uploadJpgFile("identityFiles");
     testPage.clickContinue();
     assertPageTitle("Add proof of virtual school enrollment");

--- a/src/test/java/org/homeschoolpebt/app/journeys/ApplyForSelfJourneyTest.java
+++ b/src/test/java/org/homeschoolpebt/app/journeys/ApplyForSelfJourneyTest.java
@@ -69,13 +69,13 @@ public class ApplyForSelfJourneyTest extends AbstractBasePageTest {
     // Students subflow
     testPage.clickButton("Get started"); // "Student information" signpost
     assertPageTitle("Add a student");
-    testPage.enter("studentFirstName", "Stud");
-    testPage.enter("studentLastName", "McStudenty");
+    testPage.enter("studentFirstName", "Testy");
+    testPage.enter("studentLastName", "McTesterson");
     testPage.enter("studentBirthdayDay", "1");
     testPage.enter("studentBirthdayMonth", "2");
     testPage.enter("studentBirthdayYear", "1991");
     testPage.clickButton("Add student");
-    assertPageTitle("Do any of the following apply to Stud?");
+    assertPageTitle("Do any of the following apply to Testy?");
     testPage.findElementById("none__checkbox").click();
     testPage.clickContinue();
     assertPageTitle("Tell us about");
@@ -200,7 +200,7 @@ public class ApplyForSelfJourneyTest extends AbstractBasePageTest {
     testPage.clickButton("Get started");
     testPage.clickButton("Got it"); // How to add files from your device
     assertPageTitle("Add proof of identity");
-    assertThat(testPage.getCssSelectorText(".boxed-content")).contains("Stud McStudenty");
+    assertThat(testPage.getCssSelectorText(".boxed-content")).contains("Testy McTesterson");
     uploadJpgFile("identityFiles");
     testPage.clickContinue();
     assertPageTitle("Add proof of virtual school enrollment");

--- a/src/test/java/org/homeschoolpebt/app/utils/SubmissionUtilitiesTest.java
+++ b/src/test/java/org/homeschoolpebt/app/utils/SubmissionUtilitiesTest.java
@@ -798,6 +798,21 @@ class SubmissionUtilitiesTest {
       );
     }
 
+    @Test
+    void includesStudentsAndHouseholdWhenPresent() {
+      var submission = Submission.builder().inputData(Map.ofEntries(
+        Map.entry("firstName", "Johnny"),
+        Map.entry("lastName", "Appleseed"),
+        Map.entry("students", List.of(student1(), student2())),
+        Map.entry("household", List.of(householdMember()))
+      )).build();
+      assertThat(SubmissionUtilities.getSelectableStudentsAndHousehold(submission, "(that's you)")).isEqualTo(
+        Map.of("Patrick Starfish", "Patrick Starfish",
+          "Sally A Starfish", "Sally A Starfish",
+          "Rodger Rocklobster", "Rodger Rocklobster")
+      );
+    }
+
 
     private HashMap<String, Object> student1() {
       return new HashMap<>() {{
@@ -816,6 +831,13 @@ class SubmissionUtilitiesTest {
         put("studentDesignations[]", List.of("none"));
         put("studentWouldAttendSchoolName", "Other custom school");
       }};
+    }
+
+    private Map<String, Object> householdMember() {
+      return Map.of(
+        "householdMemberFirstName", "Patrick",
+        "householdMemberLastName", "Starfish"
+      );
     }
   }
 }


### PR DESCRIPTION
Remove duplicate name in income household list when applicant is in household and is not applying for self

see #236 