### PR TITLE
Use validated address (if selected) on "reviewPersonalInfo"

### DIFF
--- a/src/main/java/org/homeschoolpebt/app/utils/SubmissionUtilities.java
+++ b/src/main/java/org/homeschoolpebt/app/utils/SubmissionUtilities.java
@@ -6,6 +6,7 @@ import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
+import org.springframework.web.util.HtmlUtils;
 
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
@@ -246,7 +247,7 @@ public class SubmissionUtilities {
     String city;
     String state;
 
-    if (submission.getInputData().get("useValidatedResidentialAddress") == "true") {
+    if (submission.getInputData().getOrDefault("useValidatedResidentialAddress", "false").equals("true")) {
       street1 = (String) submission.getInputData().get("residentialAddressStreetAddress1_validated");
       street2 = (String) submission.getInputData().getOrDefault("residentialAddressStreetAddress2_validated", "");
       city = (String) submission.getInputData().get("residentialAddressCity_validated");
@@ -267,8 +268,42 @@ public class SubmissionUtilities {
     }
   }
 
+  /**
+   * Return the combined mailing address suitable for multiline HTML display.
+   *
+   * @param submission submssion contains the submittedAt instance variable that holds the
+   *                   date the application was submitted.
+   * @return a string of HTML containing the address.
+   */
+  public static String combinedAddressHtml(Submission submission) {
+    String street1;
+    String street2;
+    String city;
+    String state;
+
+    if (submission.getInputData().getOrDefault("useValidatedResidentialAddress", "false").equals("true")) {
+      street1 = HtmlUtils.htmlEscape((String) submission.getInputData().getOrDefault("residentialAddressStreetAddress1_validated", ""));
+      street2 = HtmlUtils.htmlEscape((String) submission.getInputData().getOrDefault("residentialAddressStreetAddress2_validated", ""));
+      city = HtmlUtils.htmlEscape((String) submission.getInputData().getOrDefault("residentialAddressCity_validated", ""));
+      state = HtmlUtils.htmlEscape((String) submission.getInputData().getOrDefault("residentialAddressState_validated", ""));
+    } else {
+      street1 = HtmlUtils.htmlEscape((String) submission.getInputData().getOrDefault("residentialAddressStreetAddress1", ""));
+      street2 = HtmlUtils.htmlEscape((String) submission.getInputData().getOrDefault("residentialAddressStreetAddress2", ""));
+      city = HtmlUtils.htmlEscape((String) submission.getInputData().getOrDefault("residentialAddressCity", ""));
+      state = HtmlUtils.htmlEscape((String) submission.getInputData().getOrDefault("residentialAddressState", ""));
+    }
+
+    if (street1.isBlank()) {
+      return "<p></p>";
+    } else if (!street2.isBlank()) {
+      return "<p>%s<br>%s<br>%s, %s</p>".formatted(street1, street2, city, state);
+    } else {
+      return "<p>%s<br>%s, %s</p>".formatted(street1, city, state);
+    }
+  }
+
   public static String zipCode(Submission submission) {
-    if (submission.getInputData().get("useValidatedResidentialAddress") == "true") {
+    if (submission.getInputData().getOrDefault("useValidatedResidentialAddress", "false").equals("true")) {
       return (String) submission.getInputData().get("residentialAddressZipCode_validated");
     } else {
       return (String) submission.getInputData().get("residentialAddressZipCode");

--- a/src/main/resources/templates/pebt/reviewPersonalInfo.html
+++ b/src/main/resources/templates/pebt/reviewPersonalInfo.html
@@ -11,21 +11,15 @@
         <th:block th:replace="~{fragments/icons :: documentsSearch}"></th:block>
         <th:block th:replace="~{'fragments/cardHeader' :: cardHeader(header=#{review-personal-info.title})}"/>
         <div class="form-card__content">
-          <h3 th:text="#{review-personal-info.name}"></h3>
+          <h3 th:text="#{review-personal-info.name}" class="spacing-below-15"></h3>
           <p th:text="${inputData.firstName + ' ' + inputData.lastName}"></p>
 
           <hr class="spacing-above-15 spacing-below-15">
-          <h3 th:text="#{review-personal-info.mailing-address}"></h3>
-          <p>
-            <span th:text="${inputData.residentialAddressStreetAddress1}"></span>
-            <br>
-            <span th:text="${inputData.residentialAddressStreetAddress2}" th:if="${inputData.residentialAddressStreetAddress2}"></span>
-            <br>
-            <span th:text="${inputData.residentialAddressCity} + ', ' + ${inputData.residentialAddressState} + ' ' + ${inputData.residentialAddressZipCode}"></span>
-          </p>
+          <h3 th:text="#{review-personal-info.mailing-address}" class="spacing-below-15"></h3>
+          <th:block th:with="text=${T(org.homeschoolpebt.app.utils.SubmissionUtilities).combinedAddressHtml(submission)}" th:utext="${text}"></th:block>
 
           <hr class="spacing-above-15 spacing-below-15">
-          <h3 th:text="#{review-personal-info.contact-information}"></h3>
+          <h3 th:text="#{review-personal-info.contact-information}" class="spacing-below-15"></h3>
           <p>
             <span th:text="${inputData.phoneNumber}" th:if="${inputData.phoneNumber}"></span>
             <br>


### PR DESCRIPTION
* Fix bug where we were using `==` to compare strings (this will fix the
  address used on the Applicant Summary PDF to match this logic).
* Create a new combinedAddressHtml method to format the address properly
  for the reviewPersonalInfo page.
* Make a couple minor changes to the spacing on that page.
