### PR TITLE
Remove docupload links from pebt flow

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -23,7 +23,7 @@ adding-documents.students-identity=Students' proof of identity
 adding-documents.subtext=You can use your phone to take photos of your documents, or add any files from your device.
 adding-documents.title=Adding Documents
 adding-documents.we-will-tell-you=We'll ask you for
-adding-documents.you-can-do-it-later=<b>You don''t need all these documents to get started.</b><br>Add what you have now, and then go to <a href\="/docs" target\="_blank">GetPEBT.org/docs</a> by {0} to submit the rest.
+adding-documents.you-can-do-it-later=<b>You don''t need all these documents to get started.</b><br>Add what you have now and submit the rest by {0}.
 address-validation.header=Make sure your address is correct
 address-validation.notFoundNotice=We couldn't find your address. To make sure you get mail from the State of California, you may edit your address or keep going.
 applicant-is-in-household.subtext=A household is any group of people who are living together and sharing income and expenses.
@@ -61,7 +61,7 @@ date-error.year-range=Make sure to enter a year that is not too long ago or too 
 delete-confirmation-back-redirect.button=Return to the screen I was on before
 delete-confirmation-back-redirect.header=This entry has already been deleted
 demo.banner-text=This site is for example purposes only.
-doc-pending-confirmation.laterdocs-instructions=You can go to <a href\="/docs" target\="_blank">GetPEBT.org/docs</a> by {0} to submit these documents later.
+doc-pending-confirmation.laterdocs-instructions=You can submit these documents by {0}.
 doc-pending-confirmation.title=We'll need the rest of your documents.
 doc-pending-confirmation.youll-still-need=You'll still need\:
 doc-submit-confirmation.header=Ready to submit your documents and finish your application?
@@ -573,12 +573,10 @@ success.header=Done\! Your application has been submitted to the State of Califo
 success.header-missing-docs=Great\! We got your application.
 success.helpful-resources=Helpful resources
 success.how-was-your-experience=How was your experience with GetPEBT.org? (optional)
-success.laterdocs-url=GetPEBT.org/docs
 success.missing-docs-notice=<p><strong>Note\:</strong> <a href\="{0}" target\="_blank">Download your Applicant Summary</a> now. You''ll need it to submit more documents later.
 success.phone-call-from-worker=In about 3 weeks, a helpline worker will contact you to update you on your application status or request more documents.
 success.save-helpline-numbers=<p class\="spacing-below-10"><strong>Save these helpline numbers</strong></p><p class\="spacing-below-10">The helpline calls you from\: <a href\="tel\:9168486998" target\="_blank">(916)-848-6998</a><br>You call the helpline at\: <a href\="tel\:8773289677">(877)-328-9677</a></p><p class\="text--help">Monday - Friday, 6am - 8pm PT</p>
 success.submit-feedback=Submit Feedback
-success.submit-more-docs=Submit more documents
 success.submitted-on=Your application was submitted the State of California on {0}.
 success.submitted-on-missing-docs=Your application has been saved and timestamped for {0}.
 success.subtext-missing-docs=<p>We''ll send your application to the State of California when we receive your required documents, or in 7 days (whichever is sooner).</p><p>Submit your required documents <strong>by {0}</strong>.</p>

--- a/src/main/resources/messages_es.properties
+++ b/src/main/resources/messages_es.properties
@@ -23,7 +23,7 @@ adding-documents.students-identity=Prueba de identidad de los estudiantes
 adding-documents.subtext=Puede usar su teléfono para tomar fotos de sus documentos o agregar cualquier archivo desde su dispositivo.
 adding-documents.title=Añadir documentos
 adding-documents.we-will-tell-you=Le pediremos lo siguiente:
-adding-documents.you-can-do-it-later=<b>No necesita todos estos documentos para comenzar.</b><br> Agregue lo que tiene ahora y luego vaya a <a href\="/docs" target\="_blank">GetPEBT.org/docs</a> para el {0} para enviar el resto.
+adding-documents.you-can-do-it-later=<b>No necesita todos estos documentos para comenzar.</b><br> Agregue lo que tiene ahora y envie el resto antes del {0}.
 address-validation.header=Asegúrese de que su dirección esté correcta
 address-validation.notFoundNotice=No pudimos encontrar su dirección. Para asegurarse de recibir correo del Estado de California, puede editar su dirección o continuar.
 applicant-is-in-household.subtext=Un hogar es cualquier grupo de personas que viven juntas y comparten ingresos y gastos.
@@ -61,7 +61,7 @@ date-error.year-range=Asegúrese de introducir un año que no sea hace mucho tiemp
 delete-confirmation-back-redirect.button=Volver a la pantalla en la que estaba antes
 delete-confirmation-back-redirect.header=Esta anotación ya ha sido eliminada
 demo.banner-text=Este sitio es sólo sirve de ejemplo.
-doc-pending-confirmation.laterdocs-instructions=Puede ir a <a href\="/docs" target\="_blank">GetPEBT.org/docs</a> para el {0} para enviar estos documentos más tarde.
+doc-pending-confirmation.laterdocs-instructions=Puede enviar estos documentos antes de el {0}.
 doc-pending-confirmation.title=Necesitaremos el resto de sus documentos.
 doc-pending-confirmation.youll-still-need=Todavía necesitarás\:
 doc-submit-confirmation.header=¿Está listo para enviar sus documentos y finalizar su solicitud?
@@ -573,12 +573,10 @@ success.header=¡Hecho\! Su solicitud ha sido enviada al Estado de California.
 success.header-missing-docs=Excelente\! Recibimos tu solicitud.
 success.helpful-resources=Recursos útiles
 success.how-was-your-experience=¿Cómo fue su experiencia con GetPEBT.org? (opcional)
-success.laterdocs-url=GetPEBT.org/docs
 success.missing-docs-notice=<p><strong>Nota\:</strong> <a href\="{0}" target\="_blank">Descargue su Resumen del Solicitante</a> ahora. Lo necesitará para enviar más documentos más adelante.
 success.phone-call-from-worker=En aproximadamente 3 semanas, un trabajador de la línea de ayuda se comunicará con usted para actualizarlo sobre el estado de su solicitud o solicitar más documentos.
 success.save-helpline-numbers=<p class\="spacing-below-10"><strong>Guarde estos números de la línea de ayuda</strong></p><p class\="spacing-below-10"> La línea de ayuda te llama desde\: <a href\="tel\:9168486998" target\="_blank">(916)-848-6998</a><br> Llame a la línea de ayuda al\: <a href\="tel\:8773289677">(877)-328-9677</a></p><p class\="text--help"> Lunes a viernes, de 6 a. m. a 8 p. m. (hora del Pacífico)</p>
 success.submit-feedback=Enviar comentarios
-success.submit-more-docs=Enviar más documentos
 success.submitted-on=Su solicitud se envió al Estado de California el {0}.
 success.submitted-on-missing-docs=Su solicitud ha sido guardada y con el sello de la hora para {0}.
 success.subtext-missing-docs=<p>Enviaremos su solicitud al Estado de California cuando recibamos los documentos requeridos o en 7 días (lo que ocurra primero).</p><p> Envíe sus documentos requeridos <strong>por {0}</strong> .</p>

--- a/src/main/resources/templates/pebt/success.html
+++ b/src/main/resources/templates/pebt/success.html
@@ -42,17 +42,6 @@
               </div>
             </div>
 
-            <div class="success-confirmation-box  spacing-below-35">
-              <div class="success-confirmation-box__icon">
-                <th:block th:replace="~{'fragments/icons' :: smallFile}"></th:block>
-              </div>
-              <div>
-                <strong th:text="#{success.submit-more-docs}"></strong>
-                <br>
-                <a href="/docs" th:utext="#{success.laterdocs-url}"></a>
-              </div>
-            </div>
-
             <div class="success-confirmation-box  spacing-below-10">
               <div class="success-confirmation-box__icon">
                 <th:block th:replace="~{'fragments/icons' :: contactPhoneSmall}"></th:block>


### PR DESCRIPTION
This is causing the `flow` attr on the `submission` to `docUpload` when we want it to remain `pebt`. This is problematic as we'll get bunch of `docUpload` submissions with extra data not from the doc upload flow, if the user does not nav back to the pebt flow (which will reset it back to `pebt`). Issue still remains on how these submissions get fragmented, but this hopefully should help 🤞 