### PR TITLE
Add doc-la logback spring settings

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,12 +1,30 @@
 <?xml version = "1.0" encoding = "UTF-8"?>
 <configuration>
-  <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="LocalConsole" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%boldCyan(%d{HH:mm:ss.SSS}) [%thread] %highlight(%-5level) %boldMagenta(%logger{36}) - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
 
-  <root level="INFO">
-    <appender-ref ref="console"/>
-  </root>
+  <appender name="JsonConsole" class="ch.qos.logback.core.ConsoleAppender">
+    <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
+      <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
+        <prettyPrint>false</prettyPrint>
+      </jsonFormatter>
+      <appendLineSeparator>true</appendLineSeparator>
+      <timestampFormat>yyyy-MM-dd' 'HH:mm:ss</timestampFormat>
+    </layout>
+  </appender>
+
+  <springProfile name="dev | test">
+    <root level="INFO">
+      <appender-ref ref="LocalConsole"/>
+    </root>
+  </springProfile>
+
+  <springProfile name="staging | demo | production">
+    <root level="INFO | WARN | ERROR">
+      <appender-ref ref="JsonConsole"/>
+    </root>
+  </springProfile>
 </configuration>


### PR DESCRIPTION
We expected to see MDC attributes in datadog after we added the logging filter. We think we also need to enable JSON Console to be able to see MDC. So we [copy/pasted the doc-la settings here](https://github.com/codeforamerica/la-doc-uploader/blob/main/src/main/resources/logback-spring.xml).