### PR TITLE
Handle duplicate original filenames in Transmitter

### DIFF
--- a/src/main/java/org/homeschoolpebt/app/cli/TransmitterCommands.java
+++ b/src/main/java/org/homeschoolpebt/app/cli/TransmitterCommands.java
@@ -140,7 +140,7 @@ public class TransmitterCommands {
             int fileCount = 0;
             for (UserFile userFile : userFiles) {
               fileCount += 1;
-              ZipEntry docEntry = new ZipEntry(subfolder + String.format("%02d", fileCount) + "_" + userFile.getOriginalName().replaceAll("[/:]", "_"));
+              ZipEntry docEntry = new ZipEntry(subfolder + String.format("%02d", fileCount) + "_" + userFile.getOriginalName().replaceAll("[/:\\\\]", "_"));
               docEntry.setSize(userFile.getFilesize().longValue());
               zos.putNextEntry(docEntry);
 

--- a/src/main/java/org/homeschoolpebt/app/cli/TransmitterCommands.java
+++ b/src/main/java/org/homeschoolpebt/app/cli/TransmitterCommands.java
@@ -111,7 +111,10 @@ public class TransmitterCommands {
     List<UUID> successfullySubmittedIds = new ArrayList<>();
     try (FileOutputStream baos = new FileOutputStream(zipFileName);
       ZipOutputStream zos = new ZipOutputStream(baos)) {
-      appIdToSubmission.forEach((appNumber, submission) -> {
+      for (var appNumberAndSubmission : appIdToSubmission.entrySet()) {
+        var appNumber = appNumberAndSubmission.getKey();
+        var submission = appNumberAndSubmission.getValue();
+
         Transmission transmission = transmissionRepository.getTransmissionBySubmission(submission);
         if (transmission != null) {
           String subfolder = createSubfolderName(submission, transmission);
@@ -119,7 +122,7 @@ public class TransmitterCommands {
             if ("pebt".equals(submission.getFlow()) && doTransmitApplication(appIdsWithLaterDocs, appNumber, submission)) {
               // generate applicant summary
               byte[] file = pdfService.getFilledOutPDF(submission);
-              String fileName = pdfService.generatePdfName(submission);
+              String fileName = "00_" + pdfService.generatePdfName(submission);
               if (!fileName.endsWith(".pdf")) {
                 fileName += ".pdf";
               }
@@ -134,8 +137,10 @@ public class TransmitterCommands {
 
             // Add uploaded docs
             List<UserFile> userFiles = transmissionRepository.userFilesBySubmission(submission);
+            int fileCount = 0;
             for (UserFile userFile : userFiles) {
-              ZipEntry docEntry = new ZipEntry(subfolder + userFile.getOriginalName());
+              fileCount += 1;
+              ZipEntry docEntry = new ZipEntry(subfolder + String.format("%02d", fileCount) + "_" + userFile.getOriginalName().replaceAll("[/:]", "_"));
               docEntry.setSize(userFile.getFilesize().longValue());
               zos.putNextEntry(docEntry);
 
@@ -150,9 +155,10 @@ public class TransmitterCommands {
             successfullySubmittedIds.add(submission.getId());
           } catch (IOException e) {
             log.error("Unable to write file for appNumber, " + appNumber, e);
+            throw e;
           }
         }
-      });
+      };
     }
     return successfullySubmittedIds;
   }

--- a/src/main/java/org/homeschoolpebt/app/data/TransmissionRepository.java
+++ b/src/main/java/org/homeschoolpebt/app/data/TransmissionRepository.java
@@ -26,7 +26,7 @@ public interface TransmissionRepository extends JpaRepository<Transmission, UUID
   @Query(value = "SELECT t FROM Transmission t WHERE t.submission = :submission")
   Transmission getTransmissionBySubmission(Submission submission);
 
-  @Query(value = "SELECT u FROM UserFile u WHERE u.submission_id = :submission")
+  @Query(value = "SELECT u FROM UserFile u WHERE u.submission_id = :submission ORDER BY u.createdAt")
   List<UserFile> userFilesBySubmission(Submission submission);
 
   @Query(value = "SELECT u FROM UserFile u WHERE u.file_id IN :ids")

--- a/src/test/java/org/homeschoolpebt/app/cli/TransmitterCommandsTest.java
+++ b/src/test/java/org/homeschoolpebt/app/cli/TransmitterCommandsTest.java
@@ -112,7 +112,7 @@ class TransmitterCommandsTest {
     UserFile docfileWeirdFilename = new UserFile();
     docfileWeirdFilename.setFilesize(10.0f);
     docfileWeirdFilename.setSubmission_id(submissionWithDocs);
-    docfileWeirdFilename.setOriginalName("weird/:filename.jpg");
+    docfileWeirdFilename.setOriginalName("weird/:\\filename.jpg");
     userFileRepository.save(docfileWeirdFilename);
 
     var docUploadOnly = Submission.builder()
@@ -185,7 +185,7 @@ class TransmitterCommandsTest {
     assertThat(fileNames, hasItem("output/1002_McOtherson/00_applicant_summary.pdf"));
     assertThat(fileNames, hasItem("output/1002_McOtherson/01_originalFilename.png"));
     assertThat(fileNames, hasItem("output/1002_McOtherson/02_originalFilename.png"));
-    assertThat(fileNames, hasItem("output/1002_McOtherson/03_weird__filename.jpg"));
+    assertThat(fileNames, hasItem("output/1002_McOtherson/03_weird___filename.jpg"));
 
     // cleanup
     zipFile.delete();

--- a/src/test/java/org/homeschoolpebt/app/cli/TransmitterCommandsTest.java
+++ b/src/test/java/org/homeschoolpebt/app/cli/TransmitterCommandsTest.java
@@ -1,6 +1,8 @@
 package org.homeschoolpebt.app.cli;
 
 import static org.assertj.core.util.DateUtil.now;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -101,6 +103,18 @@ class TransmitterCommandsTest {
     docfile.setOriginalName("originalFilename.png");
     userFileRepository.save(docfile);
 
+    UserFile docfile_same_name = new UserFile();
+    docfile_same_name.setFilesize(10.0f);
+    docfile_same_name.setSubmission_id(submissionWithDocs);
+    docfile_same_name.setOriginalName("originalFilename.png");
+    userFileRepository.save(docfile_same_name);
+
+    UserFile docfile_weird_filename = new UserFile();
+    docfile_weird_filename.setFilesize(10.0f);
+    docfile_weird_filename.setSubmission_id(submissionWithDocs);
+    docfile_weird_filename.setOriginalName("weird/:filename.jpg");
+    userFileRepository.save(docfile_weird_filename);
+
     var docUploadOnly = Submission.builder()
       .submittedAt(now())
       .flow("docUpload")
@@ -163,13 +177,15 @@ class TransmitterCommandsTest {
     String destDir = "output";
     List<String> fileNames = unzip(zipFile.getPath(), destDir);
 
-    assertEquals(6, fileNames.size());
-    assertTrue(fileNames.contains("output/1001_McTest/"));
-    assertTrue(fileNames.contains("output/1001_McTest/applicant_summary.pdf"));
-    assertTrue(fileNames.contains("output/LaterDoc_1001_McTest_Tester/laterdoc.png"));
-    assertTrue(fileNames.contains("output/1002_McOtherson/"));
-    assertTrue(fileNames.contains("output/1002_McOtherson/applicant_summary.pdf"));
-    assertTrue(fileNames.contains("output/1002_McOtherson/originalFilename.png"));
+    assertEquals(8, fileNames.size());
+    assertThat(fileNames, hasItem("output/1001_McTest/"));
+    assertThat(fileNames, hasItem("output/1001_McTest/00_applicant_summary.pdf"));
+    assertThat(fileNames, hasItem("output/LaterDoc_1001_McTest_Tester/01_laterdoc.png"));
+    assertThat(fileNames, hasItem("output/1002_McOtherson/"));
+    assertThat(fileNames, hasItem("output/1002_McOtherson/00_applicant_summary.pdf"));
+    assertThat(fileNames, hasItem("output/1002_McOtherson/01_originalFilename.png"));
+    assertThat(fileNames, hasItem("output/1002_McOtherson/02_originalFilename.png"));
+    assertThat(fileNames, hasItem("output/1002_McOtherson/03_weird__filename.jpg"));
 
     // cleanup
     zipFile.delete();

--- a/src/test/java/org/homeschoolpebt/app/cli/TransmitterCommandsTest.java
+++ b/src/test/java/org/homeschoolpebt/app/cli/TransmitterCommandsTest.java
@@ -103,17 +103,17 @@ class TransmitterCommandsTest {
     docfile.setOriginalName("originalFilename.png");
     userFileRepository.save(docfile);
 
-    UserFile docfile_same_name = new UserFile();
-    docfile_same_name.setFilesize(10.0f);
-    docfile_same_name.setSubmission_id(submissionWithDocs);
-    docfile_same_name.setOriginalName("originalFilename.png");
-    userFileRepository.save(docfile_same_name);
+    UserFile docfileSameName = new UserFile();
+    docfileSameName.setFilesize(10.0f);
+    docfileSameName.setSubmission_id(submissionWithDocs);
+    docfileSameName.setOriginalName("originalFilename.png");
+    userFileRepository.save(docfileSameName);
 
-    UserFile docfile_weird_filename = new UserFile();
-    docfile_weird_filename.setFilesize(10.0f);
-    docfile_weird_filename.setSubmission_id(submissionWithDocs);
-    docfile_weird_filename.setOriginalName("weird/:filename.jpg");
-    userFileRepository.save(docfile_weird_filename);
+    UserFile docfileWeirdFilename = new UserFile();
+    docfileWeirdFilename.setFilesize(10.0f);
+    docfileWeirdFilename.setSubmission_id(submissionWithDocs);
+    docfileWeirdFilename.setOriginalName("weird/:filename.jpg");
+    userFileRepository.save(docfileWeirdFilename);
 
     var docUploadOnly = Submission.builder()
       .submittedAt(now())


### PR DESCRIPTION
Also:

- Store applicant summary as 00_applicant_summary.pdf for alphabetical ordering ease-of-use
- Convert messy characters / and : into _ to avoid path traversal or other oddities
- Sort user files deterministically to ensure filename ordering stays consistent
- Allow IOException to bubble up (was being squelched presumably because lambdas cannot throw)