### PR TITLE
Add redirect to homepage when missing data

### DIFF
--- a/src/main/java/org/homeschoolpebt/app/config/DataRequiredHandlerConfiguration.java
+++ b/src/main/java/org/homeschoolpebt/app/config/DataRequiredHandlerConfiguration.java
@@ -1,0 +1,19 @@
+package org.homeschoolpebt.app.config;
+
+import formflow.library.data.SubmissionRepositoryService;
+import org.homeschoolpebt.app.submission.interceptors.DataRequiredInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class DataRequiredHandlerConfiguration implements WebMvcConfigurer {
+  @Autowired
+  SubmissionRepositoryService submissionRepositoryService;
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(new DataRequiredInterceptor(this.submissionRepositoryService)).addPathPatterns(DataRequiredInterceptor.PATH_FORMAT);
+  }
+}

--- a/src/main/java/org/homeschoolpebt/app/submission/interceptors/DataRequiredInterceptor.java
+++ b/src/main/java/org/homeschoolpebt/app/submission/interceptors/DataRequiredInterceptor.java
@@ -1,0 +1,135 @@
+package org.homeschoolpebt.app.submission.interceptors;
+
+import formflow.library.data.SubmissionRepositoryService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Component
+@Slf4j
+public class DataRequiredInterceptor implements HandlerInterceptor {
+  public static final String PATH_FORMAT = "/flow/{flow}/{screen}";
+  private final SubmissionRepositoryService submissionRepositoryService;
+  private static final Map<String, String> REQUIRED_DATA = Map.ofEntries(
+    // Step 1
+    Map.entry("preScreenApplyingForSelf", "hasMoreThanOneStudent"),
+    Map.entry("preScreenEnrolledInVirtualSchool", "hasMoreThanOneStudent"),
+    Map.entry("preScreenUnenrolled", "hasMoreThanOneStudent"),
+    Map.entry("preScreenUnenrolledSchoolName", "hasMoreThanOneStudent"),
+    Map.entry("preScreenIneligible", "hasMoreThanOneStudent"),
+    Map.entry("eligibilityLikely", "hasMoreThanOneStudent"),
+
+    // Step 2
+    Map.entry("studentsSignpost", "hasMoreThanOneStudent"),
+    Map.entry("studentsAdd", "hasMoreThanOneStudent"),
+    Map.entry("studentsDesignations", "hasMoreThanOneStudent"),
+    Map.entry("studentsSchoolYear", "hasMoreThanOneStudent"),
+    Map.entry("studentsUnenrolledSchoolName", "hasMoreThanOneStudent"),
+    Map.entry("studentsWouldAttendSchoolName", "hasMoreThanOneStudent"),
+    Map.entry("studentsSummary", "hasMoreThanOneStudent"),
+    Map.entry("studentsDeleteConfirmation", "hasMoreThanOneStudent"),
+    Map.entry("applicantIsInHousehold", "hasMoreThanOneStudent"),
+    Map.entry("eligibilityStudents", "hasMoreThanOneStudent"),
+
+    // Step 3
+    Map.entry("gettingToKnowYou", "hasMoreThanOneStudent"),
+    Map.entry("personalInfo", "hasMoreThanOneStudent"),
+    Map.entry("homeAddress", "firstName"),
+    Map.entry("pickHomeAddress", "firstName"),
+    Map.entry("verifyHomeAddress", "firstName"),
+    Map.entry("contactInfo", "firstName"),
+    Map.entry("confirmBlankEmail", "firstName"),
+    Map.entry("reviewPersonalInfo", "firstName"),
+
+    // Step 4
+    Map.entry("housemates", "firstName"),
+    Map.entry("signpostHouseholdDetails", "firstName"),
+    Map.entry("housemateInfo", "firstName"),
+    Map.entry("householdList", "firstName"),
+    Map.entry("householdReceivesBenefits", "firstName"),
+    Map.entry("householdDeleteConfirmation", "firstName"),
+
+    // Step 5
+    Map.entry("signpostIncome", "firstName"),
+    Map.entry("hasIncome", "firstName"),
+    Map.entry("incomeAddJob", "firstName"),
+    Map.entry("incomeChooseHouseholdMember", "firstName"),
+    Map.entry("incomeJobName", "firstName"),
+    Map.entry("incomeSelfEmployed", "firstName"),
+    Map.entry("incomeIsJobHourly", "firstName"),
+    Map.entry("incomeHourlyWageCalculator", "firstName"),
+    Map.entry("incomeGrossMonthlyIndividual", "firstName"),
+    Map.entry("incomeRegularPayCalculator", "firstName"),
+    Map.entry("incomeWillBeLessYearly", "firstName"),
+    Map.entry("incomeWillBeLessMonthly", "firstName"),
+    Map.entry("incomeSelfEmployedGrossMonthly", "firstName"),
+    Map.entry("incomeSelfEmployedOperatingExpenses", "firstName"),
+    Map.entry("incomeSelfEmployedWillBeLess", "firstName"),
+    Map.entry("incomeReview", "firstName"),
+    Map.entry("incomeEarnedIncomeComplete", "firstName"),
+    Map.entry("incomeUnearnedRetirementTypes", "firstName"),
+    Map.entry("incomeUnearnedTypes", "firstName"),
+    Map.entry("incomeUnearnedAmounts", "firstName"),
+    Map.entry("incomeComplete", "firstName"),
+    Map.entry("incomeDeleteConfirmation", "firstName"),
+
+    // Step 6
+    Map.entry("addingDocuments", "firstName"),
+    Map.entry("docUploadHowTo", "firstName"),
+    Map.entry("uploadIdentityDocuments", "firstName"),
+    Map.entry("uploadEnrollmentDocuments", "firstName"),
+    Map.entry("uploadIncomeDocuments", "firstName"),
+    Map.entry("uploadUnearnedIncomeDocuments", "firstName"),
+    Map.entry("docPendingConfirmation", "firstName"),
+    Map.entry("docSubmitConfirmation", "firstName"),
+
+    // Step 7
+    Map.entry("submitting", "firstName"),
+    Map.entry("legalStuff", "firstName"),
+    Map.entry("signName", "firstName"),
+    Map.entry("success", "firstName")
+  );
+
+  public DataRequiredInterceptor(SubmissionRepositoryService submissionRepositoryService) {
+    this.submissionRepositoryService = submissionRepositoryService;
+  }
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+    try {
+      var parsedUrl = new AntPathMatcher().extractUriTemplateVariables(PATH_FORMAT, request.getRequestURI());
+      if (!parsedUrl.get("flow").equals("pebt")) {
+        return true; // Only enforce data requirements in PEBT flow.
+      }
+      var requiredData = REQUIRED_DATA.get(parsedUrl.get("screen"));
+      if (requiredData == null) {
+        return true; // There are no data requirements for this page
+      }
+
+      var submissionId = (UUID) request.getSession(false).getAttribute("id");
+      if (submissionId != null) {
+        var submissionMaybe = this.submissionRepositoryService.findById(submissionId);
+        if (submissionMaybe.isPresent()) {
+          var submission = submissionMaybe.get();
+          if (submission.getInputData().getOrDefault(requiredData, "").toString().isBlank()) {
+            log.error("Submission %s missing field data %s, redirecting to homepage".formatted(submissionId, requiredData));
+            response.sendRedirect("/");
+          }
+        } else {
+          log.error("Submission %s not found in database (required field %s), redirecting to homepage".formatted(submissionId, requiredData));
+          response.sendRedirect("/");
+        }
+      }
+
+      return true;
+    } catch (IllegalStateException e) {
+      return true;
+    }
+  }
+}

--- a/src/test/java/org/homeschoolpebt/app/journeys/DataValidationJourneyTest.java
+++ b/src/test/java/org/homeschoolpebt/app/journeys/DataValidationJourneyTest.java
@@ -1,0 +1,20 @@
+package org.homeschoolpebt.app.journeys;
+
+import org.homeschoolpebt.app.utils.AbstractBasePageTest;
+import org.junit.jupiter.api.Test;
+
+public class DataValidationJourneyTest extends AbstractBasePageTest {
+  @Test
+  void testRedirectingHome() {
+    // Landing screen
+    assertPageTitle("Get food money for students TK-12.");
+    testPage.clickButton("Apply now");
+    // How this works
+    testPage.clickContinue();
+
+    // Pre-screen
+    testPage.clickButton("Ok, I'm ready");
+    driver.navigate().to("http://localhost:%s/flow/pebt/studentsSignpost".formatted(localServerPort));
+    assertPageTitle("Get food money for students TK-12.");
+  }
+}


### PR DESCRIPTION
This implements a basic "redirect to homepage" functionality when we
detect the session has been split. We detect a split based on:
1. Before the "personalInfo" page, the absence of
   "hasMoreThanOneStudent".
2. After the "personalInfo" page, the absence of the "firstName" field.

This logic is implemented in an Interceptor, which runs outside the
controllers. As such, it has to parse the URL the same way that the
controller would in order to determine which screen is shown. This is
pretty hacky and I'd prefer pretty much any other way.
