### PR TITLE
Revamps the log filter logic so it doesn't accidentally create a new session.

### DIFF
--- a/src/main/java/org/homeschoolpebt/app/filters/LoggingFilter.java
+++ b/src/main/java/org/homeschoolpebt/app/filters/LoggingFilter.java
@@ -23,14 +23,19 @@ public class LoggingFilter implements Filter {
   public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
                        FilterChain filterChain) throws ServletException, IOException {
     HttpServletRequest request = (HttpServletRequest) servletRequest;
-    HttpSession session = request.getSession();
-    UUID id = (UUID) session.getAttribute("id");
+    HttpSession session = request.getSession(false);
+    UUID subId = session != null ? (UUID) session.getAttribute("id") : null;
+    String sessionId = session != null ? session.getId() : "unset/expired";
+    String sessionCreatedAt = session != null ?
+        new DateTime(session.getCreationTime()).toString("HH:mm:ss.SSS") :
+        "no session";
 
-    MDC.put("sessionId", session.getId());
-    MDC.put("submissionId", id == null ? "null" : id.toString());
-    MDC.put("sessionCreatedAt", new DateTime(session.getCreationTime()).toString("HH:mm:ss.SSS"));
+    MDC.put("sessionId", sessionId);
+    MDC.put("sessionCreatedAt", sessionCreatedAt);
+    MDC.put("submissionId", subId == null ? "null" : subId.toString());
     MDC.put("method", request.getMethod());
     MDC.put("request", request.getRequestURI());
+
     filterChain.doFilter(servletRequest, servletResponse);
     MDC.clear();
   }


### PR DESCRIPTION
This changes the logic so that the HttpServletRequest doesn't accidentally create a session when [getSession](https://jakarta.ee/specifications/servlet/4.0/apidocs/javax/servlet/http/httpservletrequest#getSession--) is called. 
Replaces it with this [getSession](https://jakarta.ee/specifications/servlet/4.0/apidocs/javax/servlet/http/httpservletrequest#getSession-boolean-) call instead. 