### PR TITLE
Pin chromedriver version for now

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -33,6 +33,8 @@ jobs:
           java-version: '17'
       - name: Set up ChromeDriver
         uses: nanasess/setup-chromedriver@v2.1.1
+        with:
+          chromerdriver-version: '115.0.5790.102'
       - uses: actions/checkout@v3
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2


### PR DESCRIPTION
This is recommended by the maintainer as a potential workaround around
network flakiness happening right now?

https://github.com/nanasess/setup-chromedriver/issues/199
