### PR TITLE
In crontab, for shell commands, do not start web app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG APTIBLE_ENV=/opt/form-flow-starter-app/.aptible.env
 RUN set -a  && \
     if [ -e ${APTIBLE_ENV} ] ; then . ${APTIBLE_ENV} ; fi && \
     ./gradlew assemble && \
-    cp /opt/form-flow-starter-app/build/libs/app.jar app.jar
+    cp ./build/libs/app.jar app.jar
 
 # Latest releases available at https://github.com/aptible/supercronic/releases
 ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.25/supercronic-linux-amd64 \

--- a/crontab
+++ b/crontab
@@ -1,5 +1,5 @@
 # Run every day at 7pm GMT/Noon PDT
-0 19 * * * java -jar /opt/form-flow-starter-app/app.jar checkForUnsubmittedDocs
+0 19 * * * java -Dspring.main.web-application-type=NONE -jar /opt/form-flow-starter-app/app.jar checkForUnsubmittedDocs
 
 # Run every day at 5pm PDT (Pausing until production issues are resolved)
-# 0 0 * * * java -jar /opt/form-flow-starter-app/app.jar transmit
+# 0 0 * * * java -Dspring.main.web-application-type=NONE -jar /opt/form-flow-starter-app/app.jar transmit


### PR DESCRIPTION
## Testing performed

The terminal transcript below shows that with the `-D` command in place, the app does not seem to crash when being launched with the `checkForUnsubmittedDocs` command.

```
asheesh@asheesh-cfa-2021-mbp homeschool-pebt % ./gradlew assemble

> Configure project :
📚Using form flow library 0.0.7.1

> Task :compileJava
/Users/asheesh/projects/homeschool-pebt/src/main/java/org/homeschoolpebt/app/config/SecurityConfiguration.java:17: warning: [removal] formLogin() in HttpSecurity has been deprecated and marked for removal
    httpSecurity.formLogin().disable();
                ^
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 warning

BUILD SUCCESSFUL in 4s
7 actionable tasks: 7 executed
asheesh@asheesh-cfa-2021-mbp homeschool-pebt % cp ./build/libs/app.jar app.jar
asheesh@asheesh-cfa-2021-mbp homeschool-pebt % java -Dspring.main.web-application-type=NONE -jar ./app.jar checkForUnsubmittedDocs
Standard Commons Logging discovery in action with spring-jcl: please remove commons-logging.jar from classpath in order to avoid potential conflicts
12:32:04,419 |-INFO in ch.qos.logback.classic.LoggerContext[default] - This is logback-classic version ?
12:32:04,434 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.xml]
12:32:04,435 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback.xml]
12:32:04,435 |-INFO in ch.qos.logback.classic.BasicConfigurator@41a0aa7d - Setting up default configuration.
12:32:04,680 |-INFO in ch.qos.logback.core.joran.spi.ConfigurationWatchList@2794eab6 - URL [jar:file:/Users/asheesh/projects/homeschool-pebt/app.jar!/BOOT-INF/classes!/logback-spring.xml] is not of type file
12:32:04,723 |-WARN in ch.qos.logback.core.model.processor.AppenderModelHandler - Appender named [LocalConsole] not referenced. Skipping further processing.
12:32:04,723 |-WARN in ch.qos.logback.core.model.processor.AppenderModelHandler - Appender named [JsonConsole] not referenced. Skipping further processing.
12:32:04,723 |-INFO in ch.qos.logback.core.model.processor.DefaultProcessor@6340e5f0 - End of configuration.
12:32:04,723 |-INFO in org.springframework.boot.logging.logback.SpringBootJoranConfigurator@45099dd3 - Registering current configuration as safe fallback point


  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::                (v3.1.1)

asheesh@asheesh-cfa-2021-mbp homeschool-pebt %

```

## Unrelated change

I revised the Docker build to do `cp ./ # ...` rather than `cp /opt/ # ...` so that I could copy-paste the literal `cp` command into my terminal to rehearse a build.