### PR TITLE
Remove "exec" from procfile command

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-cron: exec supercronic /opt/form-flow-starter-app/crontab
+cron: supercronic /opt/form-flow-starter-app/crontab
 cmd: java -jar /opt/form-flow-starter-app/app.jar


### PR DESCRIPTION
Starting with the most recent deploy, we started getting this error:

```
/entrypoint.sh: exec: line 29: exec: not found
```
