### PR TITLE
Add ad-hoc LastMinuteReminderMessage

### DIFF
--- a/src/main/java/org/homeschoolpebt/app/cli/AdHocMessenger.java
+++ b/src/main/java/org/homeschoolpebt/app/cli/AdHocMessenger.java
@@ -1,0 +1,48 @@
+package org.homeschoolpebt.app.cli;
+
+import formflow.library.data.Submission;
+import lombok.extern.slf4j.Slf4j;
+import org.homeschoolpebt.app.data.SentMessageRepositoryService;
+import org.homeschoolpebt.app.data.TransmissionRepository;
+import org.homeschoolpebt.app.submission.messages.LastMinuteReminderMessage;
+import org.homeschoolpebt.app.submission.messages.ScheduledMessages;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.shell.standard.ShellComponent;
+import org.springframework.shell.standard.ShellMethod;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@ShellComponent
+public class AdHocMessenger {
+  @Autowired
+  TransmissionRepository transmissionRepository;
+  @Autowired
+  ScheduledMessages scheduledMessages;
+  @Autowired SentMessageRepositoryService sentMessageRepositoryService;
+
+  @ShellMethod(key = "triggerLastMinuteReminderMessages")
+  void triggerLastMinuteReminderMessages() {
+    log.info("Getting list of submitted and unsubmitted emails");
+    List<Submission> submitted = this.transmissionRepository.submissionsSubmittedWithEmail();
+    List<Submission> unsubmitted = this.transmissionRepository.submissionsUnsubmittedWithEmail();
+
+    Set<String> submittedEmails = submitted.stream().map(submission -> normalizeEmail((String) submission.getInputData().get("email"))).collect(Collectors.toSet());
+    List<Submission> submissionsThatNeedReminders = unsubmitted.stream().filter(submission -> {
+      var email = normalizeEmail((String) submission.getInputData().get("email"));
+      return !submittedEmails.contains(email);
+    }).toList();
+    List<Submission> submissionsToSendReminders = sentMessageRepositoryService.filterPastRecipients(submissionsThatNeedReminders, LastMinuteReminderMessage.class.getSimpleName());
+    log.info("Found {} submissions that need the LastMinuteReminderMessage", submissionsToSendReminders.size());
+
+    for (var submission : submissionsToSendReminders) {
+      scheduledMessages.sendLastMinuteReminderMessage(submission);
+    }
+  }
+
+  private String normalizeEmail(String email) {
+    return email.trim().toLowerCase();
+  }
+}

--- a/src/main/java/org/homeschoolpebt/app/data/SentMessageRepository.java
+++ b/src/main/java/org/homeschoolpebt/app/data/SentMessageRepository.java
@@ -1,10 +1,16 @@
 package org.homeschoolpebt.app.data;
 
+import formflow.library.data.Submission;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface SentMessageRepository extends JpaRepository<SentMessage, UUID> {
+  @Query("SELECT sm FROM SentMessage sm WHERE sm.submission IN :submissions AND sm.messageName = :messageName AND sm.sentAt IS NOT NULL")
+  List<SentMessage> findAllBySubmissionsAndMessageName(@Param("submissions") List<Submission> submissions, @Param("messageName") String messageName);
 }

--- a/src/main/java/org/homeschoolpebt/app/data/SentMessageRepositoryService.java
+++ b/src/main/java/org/homeschoolpebt/app/data/SentMessageRepositoryService.java
@@ -1,8 +1,14 @@
 package org.homeschoolpebt.app.data;
 
+import formflow.library.data.Submission;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -12,5 +18,14 @@ public class SentMessageRepositoryService {
 
   public SentMessage save(SentMessage sentMessage) {
     return sentMessageRepository.save(sentMessage);
+  }
+
+  public List<Submission> filterPastRecipients(List<Submission> submissions, String messageName) {
+    List<SentMessage> sentMessages = sentMessageRepository.findAllBySubmissionsAndMessageName(submissions, messageName);
+    Set<UUID> sentSubmissionIds = sentMessages.stream()
+        .map(sentMessage -> sentMessage.getSubmission().getId())
+          .collect(Collectors.toSet());
+
+    return submissions.stream().filter(submission -> !sentSubmissionIds.contains(submission.getId())).toList();
   }
 }

--- a/src/main/java/org/homeschoolpebt/app/data/TransmissionRepository.java
+++ b/src/main/java/org/homeschoolpebt/app/data/TransmissionRepository.java
@@ -31,4 +31,15 @@ public interface TransmissionRepository extends JpaRepository<Transmission, UUID
 
   @Query(value = "SELECT u FROM UserFile u WHERE u.file_id IN :ids")
   List<UserFile> userFilesByID(@Param("ids") List<UUID> ids);
+
+  // These should be in SubmissionRepository but can't because it's in the FFL:
+  @Query(value = "SELECT s FROM Submission s " +
+    "WHERE s.submittedAt IS NULL " +
+    "AND jsonb_extract_path_text(s.inputData, 'email') IS NOT NULL")
+  List<Submission> submissionsUnsubmittedWithEmail();
+
+  @Query(value = "SELECT s FROM Submission s " +
+    "WHERE s.submittedAt IS NOT NULL " +
+    "AND jsonb_extract_path_text(s.inputData, 'email') IS NOT NULL")
+  List<Submission> submissionsSubmittedWithEmail();
 }

--- a/src/main/java/org/homeschoolpebt/app/submission/messages/LastMinuteReminderMessage.java
+++ b/src/main/java/org/homeschoolpebt/app/submission/messages/LastMinuteReminderMessage.java
@@ -1,0 +1,49 @@
+package org.homeschoolpebt.app.submission.messages;
+
+import formflow.library.data.Submission;
+import org.homeschoolpebt.app.utils.SubmissionUtilities;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.util.StringUtils;
+
+import static org.homeschoolpebt.app.utils.SubmissionUtilities.getSubmissionLanguage;
+
+@Component
+public class LastMinuteReminderMessage implements PebtMessage {
+  Submission submission;
+
+  public LastMinuteReminderMessage(Submission submission) {
+    this.submission = submission;
+  }
+
+  @Override
+  public Email renderEmail() {
+    var applicantFullName = SubmissionUtilities.applicantFullName(submission);
+    String subject;
+    String body;
+    if (getSubmissionLanguage(submission).equals("es")) {
+      subject = "TODO";
+      body = """
+        <html>
+          <body>
+            TODO
+          </body>
+        </html>
+        """.formatted(StringUtils.escapeXml(applicantFullName));
+    } else {
+      subject = "TODO";
+      body = """
+        <html>
+          <body>
+            TODO
+          </body>
+        </html>
+        """.formatted(StringUtils.escapeXml(applicantFullName));
+    }
+    return new Email(subject, body);
+  }
+
+  @Override
+  public Sms renderSms() {
+    return null;
+  }
+}

--- a/src/main/java/org/homeschoolpebt/app/submission/messages/LastMinuteReminderMessage.java
+++ b/src/main/java/org/homeschoolpebt/app/submission/messages/LastMinuteReminderMessage.java
@@ -21,20 +21,26 @@ public class LastMinuteReminderMessage implements PebtMessage {
     String subject;
     String body;
     if (getSubmissionLanguage(submission).equals("es")) {
-      subject = "TODO";
+      subject = "Tu solicitud para P-EBT 4.0 está incompleta (¡Las solicitudes cierran el 15 de agosto!)";
       body = """
         <html>
           <body>
-            TODO
+            <p>Estimado %s,</p>
+            <p>Gracias por tu interés en el programa P-EBT 4.0 de California. ¡Parece que comenzaste la solicitud, pero falta que la termines. Este es un recordatorio de que la solicitud se cerrará el martes 15 de agosto. Si aún deseas aplicar, visita la página <a href="https://www.getpebt.org">https://www.getpebt.org</a>.
+            <p>Gracias por su interés en nuestro programa.</p>
+            <p>- El Departamento de Servicios Sociales de California</p>
           </body>
         </html>
         """.formatted(StringUtils.escapeXml(applicantFullName));
     } else {
-      subject = "TODO";
+      subject = "Your PEBT 4.0 application is incomplete (Applications close on August 15th!)";
       body = """
         <html>
           <body>
-            TODO
+            <p>Dear %s,</p>
+            <p>Thank you for your interest in California's P-EBT 4.0 program. It looks like you started an application, but didn't finish it yet. This is a friendly reminder that the application will close on <strong>Tuesday, August 15th</strong>. If you still want to apply, go to <a href="https://www.getpebt.org">https://www.getpebt.org</a>.</p>
+            <p>Thank you for your interest in our program.</p>
+            <p>- California Department of Social Services</p>
           </body>
         </html>
         """.formatted(StringUtils.escapeXml(applicantFullName));

--- a/src/test/java/org/homeschoolpebt/app/cli/AdHocMessengerTest.java
+++ b/src/test/java/org/homeschoolpebt/app/cli/AdHocMessengerTest.java
@@ -1,0 +1,65 @@
+package org.homeschoolpebt.app.cli;
+
+import formflow.library.data.Submission;
+import formflow.library.data.SubmissionRepository;
+import org.homeschoolpebt.app.data.SentMessage;
+import org.homeschoolpebt.app.data.SentMessageRepository;
+import org.homeschoolpebt.app.submission.messages.LastMinuteReminderMessage;
+import org.homeschoolpebt.app.submission.messages.ScheduledMessages;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class AdHocMessengerTest {
+  @Autowired AdHocMessenger adHocMessenger;
+  @Autowired SubmissionRepository submissionRepository;
+  @Autowired SentMessageRepository sentMessageRepository;
+  @MockBean ScheduledMessages scheduledMessages;
+
+  @Test
+  void sendsForTheRightSubmission() {
+    var unsubmitted1 = Submission.builder().flow("pebt").inputData(new HashMap<>(Map.ofEntries(
+      Map.entry("email", "test@example.com")
+    ))).build();
+    var unsubmitted2 = Submission.builder().flow("pebt").inputData(new HashMap<>(Map.ofEntries(
+      Map.entry("email", "test2@example.com")
+    ))).build();
+    var submitted1 = Submission.builder().flow("pebt").submittedAt(new Date()).inputData(new HashMap<>(Map.ofEntries(
+      Map.entry("email", "teSt@example.com")
+    ))).build();
+    this.submissionRepository.save(unsubmitted1);
+    this.submissionRepository.save(unsubmitted2);
+    this.submissionRepository.save(submitted1);
+
+    this.adHocMessenger.triggerLastMinuteReminderMessages();
+
+    verify(this.scheduledMessages).sendLastMinuteReminderMessage(unsubmitted2);
+    verify(this.scheduledMessages, never()).sendLastMinuteReminderMessage(unsubmitted1);
+    verify(this.scheduledMessages, never()).sendLastMinuteReminderMessage(submitted1);
+  }
+
+  @Test
+  void skipsAnyPastRecipients() {
+    var unsubmitted1 = Submission.builder().flow("pebt").inputData(new HashMap<>(Map.ofEntries(
+      Map.entry("email", "test@example.com")
+    ))).build();
+    var sentMessage1 = SentMessage.builder().sentAt(new Date()).messageName(LastMinuteReminderMessage.class.getSimpleName()).submission(unsubmitted1).build();
+    this.submissionRepository.save(unsubmitted1);
+    this.sentMessageRepository.save(sentMessage1);
+
+    this.adHocMessenger.triggerLastMinuteReminderMessages();
+
+    verify(this.scheduledMessages, never()).sendLastMinuteReminderMessage(unsubmitted1);
+  }
+}


### PR DESCRIPTION
This message will go out to any unsubmitted submission that has an email
address provided (currently ~3200). To do that, most easily, we'll do
the set intersection in Java.

Since this runs the risk of error, we'll make this idempotent by
checking for a SentMessage record first before re-sending. So hopefully
if there's an error, we can re-run this.
